### PR TITLE
feat(i18n): phase 3

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,17 @@
+name: Setup pnpm workspace
+description: Set up pnpm and Node.js, and install dependencies.
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 9
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: pnpm
+
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,68 +1,40 @@
-name: CI
+name: Deploy
 
 on:
   push:
-  pull_request:
+    branches:
+      - main
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm run lint
 
   typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm run typecheck
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm run test
 
   build:
-    if: github.ref == 'refs/heads/main'
     needs: [lint, typecheck, test]
     runs-on: ubuntu-latest
     env:
       VITE_PROXY_API_BASE_URL: ${{ vars.VITE_PROXY_API_BASE_URL }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - uses: actions/configure-pages@v5
       - run: pnpm run build
       - run: cp build/client/index.html build/client/404.html
@@ -71,7 +43,6 @@ jobs:
           path: build/client
 
   deploy:
-    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,26 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,19 @@ Good fits:
 
 If something is primarily an object model with named fields, it probably belongs in `interfaces/` instead.
 
+When a file only needs another module for type extraction, prefer type-only references that do not pull the module into the runtime graph unnecessarily.
+
+Prefer patterns such as:
+
+- `type LocaleShape = typeof import('../i18n/locales/zh-TW').zhTW`
+
+Avoid patterns such as:
+
+- value imports used only for type extraction
+- `import type { zhTW } ...` combined with `typeof zhTW`
+
+This keeps type references explicit, avoids unnecessary runtime imports, and makes translation-key typing easier to maintain.
+
 ### `app/modules/enums/`
 
 Use enums for stable, domain-level categorical values such as city, direction, or status types.

--- a/app/components/AppNavLink.tsx
+++ b/app/components/AppNavLink.tsx
@@ -4,9 +4,10 @@ import { Link, useMatch, useResolvedPath } from 'react-router'
 
 export interface AppNavLinkPropType {
   to: string
-	label?: string
-	icon?: ReactElement
-	iconActive?: ReactElement
+  label?: string
+  ariaLabel?: string
+  icon?: ReactElement
+  iconActive?: ReactElement
 }
 
 export const AppNavLink = (props: AppNavLinkPropType) => {
@@ -17,9 +18,10 @@ export const AppNavLink = (props: AppNavLinkPropType) => {
     <NavLink
       component={Link}
       to={props.to}
+      aria-label={props.ariaLabel ?? props.label}
       label={(
         <Flex align="center" justify="center" direction="column">
-          {Boolean(props.label) && props.label}
+          {props.label}
           {props.icon && isActive ? props.iconActive : props.icon}
         </Flex>
       )}

--- a/app/components/AppNavLink.tsx
+++ b/app/components/AppNavLink.tsx
@@ -1,14 +1,20 @@
 import { Flex, NavLink } from '@mantine/core'
 import type { ReactElement } from 'react'
 import { Link, useMatch, useResolvedPath } from 'react-router'
+import type { RequireAtLeastOne } from '~/modules/types/RequireAtLeastOne'
 
-export interface AppNavLinkPropType {
+interface AppNavLinkBaseProps {
   to: string
-  label?: string
-  ariaLabel?: string
   icon?: ReactElement
   iconActive?: ReactElement
 }
+
+type AppNavLinkAccessibleName = RequireAtLeastOne<{
+  label: string
+  ariaLabel: string
+}>
+
+export type AppNavLinkPropType = AppNavLinkBaseProps & AppNavLinkAccessibleName
 
 export const AppNavLink = (props: AppNavLinkPropType) => {
   const resolvedPath = useResolvedPath(props.to)

--- a/app/components/AppNavLink.tsx
+++ b/app/components/AppNavLink.tsx
@@ -4,7 +4,7 @@ import { Link, useMatch, useResolvedPath } from 'react-router'
 
 export interface AppNavLinkPropType {
   to: string
-	label: string
+	label?: string
 	icon?: ReactElement
 	iconActive?: ReactElement
 }
@@ -19,7 +19,7 @@ export const AppNavLink = (props: AppNavLinkPropType) => {
       to={props.to}
       label={(
         <Flex align="center" justify="center" direction="column">
-          {props.label}
+          {Boolean(props.label) && props.label}
           {props.icon && isActive ? props.iconActive : props.icon}
         </Flex>
       )}

--- a/app/components/AppNavLink.tsx
+++ b/app/components/AppNavLink.tsx
@@ -28,7 +28,7 @@ export const AppNavLink = (props: AppNavLinkPropType) => {
       label={(
         <Flex align="center" justify="center" direction="column">
           {props.label}
-          {props.icon && isActive ? props.iconActive : props.icon}
+          {isActive ? (props.iconActive ?? props.icon) : props.icon}
         </Flex>
       )}
       active={isActive}

--- a/app/components/AreaSelect.test.tsx
+++ b/app/components/AreaSelect.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { AreaSelect } from './AreaSelect'
 import { AreaType } from '~/modules/enums/AreaType'
-import { areaMapAreaName } from '~/modules/consts/area'
+import i18n from '~/modules/i18n'
 
 vi.mock('@mantine/core', () => ({
   Select: ({
@@ -60,7 +60,7 @@ describe('AreaSelect', () => {
     const areaSelect = () => within(container).getByLabelText('area-select')
 
     expect(areaSelect()).toHaveValue(AreaType.TAIPEI)
-    expect((within(areaSelect()).getByRole('option', { name: areaMapAreaName[AreaType.TAIPEI] }) as HTMLOptionElement).selected).toBe(true)
+    expect((within(areaSelect()).getByRole('option', { name: i18n.t('common.area.Taipei') }) as HTMLOptionElement).selected).toBe(true)
 
     rerender(
       <AreaSelect
@@ -70,6 +70,6 @@ describe('AreaSelect', () => {
     )
 
     expect(areaSelect()).toHaveValue(AreaType.TAICHUNG)
-    expect((within(areaSelect()).getByRole('option', { name: areaMapAreaName[AreaType.TAICHUNG] }) as HTMLOptionElement).selected).toBe(true)
+    expect((within(areaSelect()).getByRole('option', { name: i18n.t('common.area.Taichung') }) as HTMLOptionElement).selected).toBe(true)
   })
 })

--- a/app/components/AreaSelect.test.tsx
+++ b/app/components/AreaSelect.test.tsx
@@ -8,16 +8,18 @@ import i18n from '~/modules/i18n'
 
 vi.mock('@mantine/core', () => ({
   Select: ({
+    'aria-label': ariaLabel,
     value,
     data,
     onChange
   }: {
+    'aria-label'?: string
     value: string
     data: Array<{ label: string, value: string }>
     onChange: (value: string | null) => void
   }) => (
     <select
-      aria-label="area-select"
+      aria-label={ariaLabel}
       value={value}
       onChange={(event) => onChange(event.target.value)}
     >
@@ -41,7 +43,7 @@ describe('AreaSelect', () => {
       />
     )
 
-    fireEvent.change(screen.getByLabelText('area-select'), {
+    fireEvent.change(screen.getByLabelText(i18n.t('components.areaSelect.ariaLabel')), {
       target: { value: AreaType.TAICHUNG }
     })
 
@@ -57,7 +59,7 @@ describe('AreaSelect', () => {
       />
     )
 
-    const areaSelect = () => within(container).getByLabelText('area-select')
+    const areaSelect = () => within(container).getByLabelText(i18n.t('components.areaSelect.ariaLabel'))
 
     expect(areaSelect()).toHaveValue(AreaType.TAIPEI)
     expect((within(areaSelect()).getByRole('option', { name: i18n.t('common.area.Taipei') }) as HTMLOptionElement).selected).toBe(true)

--- a/app/components/AreaSelect.tsx
+++ b/app/components/AreaSelect.tsx
@@ -27,7 +27,7 @@ export const AreaSelect = (props: AreaSelectPropType): ReactElement => {
   return (
     <Select
       aria-label={t('components.areaSelect.ariaLabel')}
-      w={80}
+      flex="0 0 124px"
       value={value}
       data={options}
       onChange={(value) => {

--- a/app/components/AreaSelect.tsx
+++ b/app/components/AreaSelect.tsx
@@ -26,6 +26,7 @@ export const AreaSelect = (props: AreaSelectPropType): ReactElement => {
 
   return (
     <Select
+      aria-label={t('components.areaSelect.ariaLabel')}
       w={80}
       value={value}
       data={options}

--- a/app/components/AreaSelect.tsx
+++ b/app/components/AreaSelect.tsx
@@ -1,7 +1,8 @@
 import { Select } from '@mantine/core'
 import { useEffect, useState, type ReactElement } from 'react'
-import { areaMapAreaName } from '~/modules/consts/area'
+import { useTranslation } from 'react-i18next'
 import { AreaType } from '~/modules/enums/AreaType'
+import { getAreaLabel } from '~/modules/utils/getAreaLabel'
 import { getEnumValues } from '~/modules/utils/getEnumValues'
 
 export interface AreaSelectPropType {
@@ -11,6 +12,7 @@ export interface AreaSelectPropType {
 }
 
 export const AreaSelect = (props: AreaSelectPropType): ReactElement => {
+  const { t } = useTranslation()
   const [value, setValue] = useState(props.value)
 
   useEffect(() => {
@@ -18,7 +20,7 @@ export const AreaSelect = (props: AreaSelectPropType): ReactElement => {
   }, [props.value])
 
   const options = getEnumValues(AreaType).map((area) => ({
-    label: areaMapAreaName[area],
+    label: getAreaLabel(t, area),
     value: area
   }))
 

--- a/app/components/GlobalModal.test.tsx
+++ b/app/components/GlobalModal.test.tsx
@@ -4,7 +4,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { busApi } from '~/modules/apis/bus'
-import { tdxRateLimitModal } from '~/modules/apis/errors/busError'
+import { getTdxRateLimitModal } from '~/modules/apis/errors/busError'
 import globalModalSlice, {
   closeGlobalModal,
   openGlobalModal
@@ -27,6 +27,7 @@ describe('GlobalModal', () => {
   it('resets bus api state when confirmAction is refresh', () => {
     const store = createTestStore()
     const dispatchSpy = vi.spyOn(store, 'dispatch')
+    const tdxRateLimitModal = getTdxRateLimitModal()
 
     store.dispatch(openGlobalModal(tdxRateLimitModal))
 

--- a/app/components/GlobalModal.tsx
+++ b/app/components/GlobalModal.tsx
@@ -38,8 +38,8 @@ export const GlobalModal = () => {
       onCancel={() => dispatch(closeGlobalModal())}
       title={title}
       variant={variant}
-      confirmText={confirmText}
-      cancelText={cancelText}
+      confirmText={confirmText ?? undefined}
+      cancelText={cancelText ?? undefined}
     >
       {message}
     </BaseModal>

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -29,7 +29,8 @@ export const SearchInput = (props: SearchInputPropType): ReactElement => {
       onChange={(e) => {
         props.onChange(e.currentTarget.value)
       }}
-      flex={1}
+      flex="1 1 0"
+      miw={0}
     />
   )
 }

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -18,6 +18,7 @@ export const SearchInput = (props: SearchInputPropType): ReactElement => {
       leftSection={<RiSearchLine />}
       rightSection={props.value && (
           <CloseButton
+            aria-label={t('components.searchInput.clearAriaLabel')}
             onClick={() => {
               props.onChange('')
             }}

--- a/app/components/common/BaseMap.tsx
+++ b/app/components/common/BaseMap.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import type { LatLng } from '~/modules/types/CoordsType'
 import type { RootState } from '~/modules/store'
-import { createMapMarkerElement } from '~/modules/utils/createMapMarkerElement'
+import { createMapMarkerElement } from '~/modules/utils/map/createMapMarkerElement'
 
 interface PropType {
   center: LatLng | null

--- a/app/components/common/BaseMap.tsx
+++ b/app/components/common/BaseMap.tsx
@@ -3,6 +3,7 @@ import { useId } from '@mantine/hooks'
 import mapLibre, { Map, Marker, LngLat as MapLngLat } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import type { LatLng } from '~/modules/types/CoordsType'
 import type { RootState } from '~/modules/store'
@@ -16,6 +17,7 @@ interface PropType {
 }
 
 const BaseMap = ({ center, zoom = 16, showUserLocation = false, onLoad }: PropType) => {
+  const { t } = useTranslation()
   const id = useId()
   const [map, setMap] = useState<Map | null>(null)
   const userMarkerRef = useRef<Marker | null>(null)
@@ -96,6 +98,7 @@ const BaseMap = ({ center, zoom = 16, showUserLocation = false, onLoad }: PropTy
     }
 
     const el = createMapMarkerElement({
+      ariaLabel: t('components.baseMap.userLocationMarkerAriaLabel'),
       boxShadow: '0 0 10px rgba(0,0,0,0.3)',
       type: 'user'
     })
@@ -108,7 +111,7 @@ const BaseMap = ({ center, zoom = 16, showUserLocation = false, onLoad }: PropTy
       userMarkerRef.current?.remove()
       userMarkerRef.current = null
     }
-  }, [map, showUserLocation, coords])
+  }, [coords, map, showUserLocation, t])
 
   return <Box id={id} style={{ width: '100%', height: '100%' }} />
 }

--- a/app/components/common/BaseModal.tsx
+++ b/app/components/common/BaseModal.tsx
@@ -1,4 +1,5 @@
 import { Button, Flex, Modal } from '@mantine/core'
+import i18n from '~/modules/i18n'
 
 type ModalVariant = 'alert' | 'confirm'
 
@@ -20,8 +21,8 @@ const BaseModal = ({
   title,
   children,
   variant = 'alert',
-  confirmText = '確定',
-  cancelText = '取消'
+  confirmText = i18n.t('common.modal.confirm'),
+  cancelText = i18n.t('common.modal.cancel')
 }: PropType) => {
   const isConfirm = variant === 'confirm'
 

--- a/app/components/common/BaseModal.tsx
+++ b/app/components/common/BaseModal.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Modal } from '@mantine/core'
-import i18n from '~/modules/i18n'
+import { useTranslation } from 'react-i18next'
 
 type ModalVariant = 'alert' | 'confirm'
 
@@ -21,10 +21,11 @@ const BaseModal = ({
   title,
   children,
   variant = 'alert',
-  confirmText = i18n.t('common.modal.confirm'),
-  cancelText = i18n.t('common.modal.cancel')
+  confirmText,
+  cancelText
 }: PropType) => {
   const isConfirm = variant === 'confirm'
+  const { t } = useTranslation()
 
   return (
     <Modal
@@ -40,10 +41,10 @@ const BaseModal = ({
       <Flex justify="flex-end" mt="md" gap="sm">
         {isConfirm && onCancel && (
           <Button variant="default" onClick={onCancel}>
-            {cancelText}
+            {cancelText ?? t('common.modal.cancel')}
           </Button>
         )}
-        <Button onClick={onConfirm}>{confirmText}</Button>
+        <Button onClick={onConfirm}>{confirmText ?? t('common.modal.confirm')}</Button>
       </Flex>
     </Modal>
   )

--- a/app/components/favorite/FavoriteRouteStopCard.tsx
+++ b/app/components/favorite/FavoriteRouteStopCard.tsx
@@ -3,9 +3,9 @@ import { RiHeart2Fill } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router'
 import { AppBadge } from '~/components/common/AppBadge'
-import { cityMapName } from '~/modules/consts/city'
-import { directionMapName } from '~/modules/consts/direction'
 import type { FavoriteRouteStop } from '~/modules/interfaces/FavoriteRouteStop'
+import { getCityLabel } from '~/modules/utils/getCityLabel'
+import { getDirectionLabel } from '~/modules/utils/getDirectionLabel'
 
 interface PropType {
   favoriteRouteStop: FavoriteRouteStop
@@ -41,11 +41,11 @@ export const FavoriteRouteStopCard = ({ favoriteRouteStop, onRemove }: PropType)
                   {[
                     favoriteRouteStop.routeName,
                     favoriteRouteStop.subRouteName === favoriteRouteStop.routeName ? null : favoriteRouteStop.subRouteName,
-                    directionMapName[favoriteRouteStop.direction]
+                    getDirectionLabel(t, favoriteRouteStop.direction)
                   ].filter(Boolean).join(' ')}
                 </AppBadge>
                 <AppBadge type="city">
-                  {cityMapName[favoriteRouteStop.city]}
+                  {getCityLabel(t, favoriteRouteStop.city)}
                 </AppBadge>
               </Group>
               <Text p="sm">

--- a/app/components/nearby/NearbySidebarContent.tsx
+++ b/app/components/nearby/NearbySidebarContent.tsx
@@ -4,10 +4,10 @@ import type { RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BaseAlert } from '~/components/common/BaseAlert'
 import { SkeletonList } from '~/components/common/SkeletonList'
-import { cityMapName } from '~/modules/consts/city'
 import type { AlertMessageConfig } from '~/modules/interfaces/AlertMessageConfig'
 import type { NearbyStopGroup } from '~/modules/interfaces/Nearby'
 import type { StationRoute } from '~/modules/interfaces/StationRoute'
+import { getCityLabel } from '~/modules/utils/getCityLabel'
 import { NearbyStopDetail } from './NearbyStopDetail'
 import { NearbyStopRoutes } from './NearbyStopRoutes'
 
@@ -57,7 +57,7 @@ const NearbySidebarContentDetail = ({ detailState }: { detailState: NearbySideba
           <Text size="sm" c="dimmed">{t('components.nearbyStopDetail.cityLabel')}</Text>
           <Text size="sm">
             {detailState.stopGroup!.City
-              ? cityMapName[detailState.stopGroup!.City]
+              ? getCityLabel(t, detailState.stopGroup!.City)
               : t('components.nearbyStopDetail.notProvided')}
           </Text>
         </Stack>

--- a/app/components/nearby/NearbyStopDetail.tsx
+++ b/app/components/nearby/NearbyStopDetail.tsx
@@ -2,9 +2,9 @@ import { ActionIcon, Flex, Skeleton, Stack, Text } from '@mantine/core'
 import { RiArrowRightSLine } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 import { AppBadge } from '~/components/common/AppBadge'
-import { cityMapName } from '~/modules/consts/city'
 import type { NearbyStopGroup } from '~/modules/interfaces/Nearby'
 import type { StationRoute } from '~/modules/interfaces/StationRoute'
+import { getCityLabel } from '~/modules/utils/getCityLabel'
 
 interface PropType {
   stopGroup: NearbyStopGroup
@@ -32,7 +32,7 @@ export const NearbyStopDetail = ({
       label: t('components.nearbyStopDetail.cityLabel'),
       content: (
         <Text size="sm">
-          {stopGroup.City ? cityMapName[stopGroup.City] : t('components.nearbyStopDetail.notProvided')}
+          {stopGroup.City ? getCityLabel(t, stopGroup.City) : t('components.nearbyStopDetail.notProvided')}
         </Text>
       )
     },

--- a/app/components/nearby/NearbyStopMap.tsx
+++ b/app/components/nearby/NearbyStopMap.tsx
@@ -2,6 +2,7 @@ import mapLibre, { Marker, Popup } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
 import type { LngLat, LatLng } from '~/modules/types/CoordsType'
 import { createMapMarkerElement } from '~/modules/utils/createMapMarkerElement'
 import BaseMap from '../common/BaseMap'
@@ -27,6 +28,7 @@ export const NearbyStopMap = ({
   isSm = false,
   onSelectStop
 }: PropType) => {
+  const { t } = useTranslation()
   const [map, setMap] = useState<mapLibre.Map | null>(null)
   const [popupContainer, setPopupContainer] = useState<HTMLDivElement | null>(null)
   const markerMap = useRef<Map<string, Marker>>(new Map<string, Marker>())
@@ -40,6 +42,7 @@ export const NearbyStopMap = ({
 
     markers.forEach(data => {
       const el = createMapMarkerElement({
+        ariaLabel: t('components.nearbyStopMap.stopMarkerAriaLabel', { stopName: data.label }),
         backgroundColor: 'var(--mantine-primary-color-filled)',
         datasetLabel: data.label,
         fontSize: '16px',
@@ -69,7 +72,7 @@ export const NearbyStopMap = ({
       })
       markerMap.current.clear()
     }
-  }, [map, markers, onSelectStop])
+  }, [map, markers, onSelectStop, t])
 
   useEffect(() => {
     if (!map || !markerMap.current.size) return

--- a/app/components/nearby/NearbyStopMap.tsx
+++ b/app/components/nearby/NearbyStopMap.tsx
@@ -37,6 +37,7 @@ export const NearbyStopMap = ({
 
   useEffect(() => {
     if (!map) return
+    const markerCleanupFns: Array<() => void> = []
 
     markerMap.current.forEach((marker) => marker.remove())
     markerMap.current.clear()
@@ -59,7 +60,7 @@ export const NearbyStopMap = ({
         onSelectStop(data.id)
       }
 
-      addMapMarkerActivationListeners(el, handleSelectStop)
+      markerCleanupFns.push(addMapMarkerActivationListeners(el, handleSelectStop))
 
       const marker = new Marker({ element: el })
         .setLngLat(data.position)
@@ -69,6 +70,7 @@ export const NearbyStopMap = ({
     })
 
     return () => {
+      markerCleanupFns.forEach((cleanup) => cleanup())
       markerMap.current.forEach((marker) => {
         marker.remove()
       })

--- a/app/components/nearby/NearbyStopMap.tsx
+++ b/app/components/nearby/NearbyStopMap.tsx
@@ -4,7 +4,8 @@ import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import type { LngLat, LatLng } from '~/modules/types/CoordsType'
-import { createMapMarkerElement } from '~/modules/utils/createMapMarkerElement'
+import { addMapMarkerActivationListeners } from '~/modules/utils/map/addMapMarkerActivationListeners'
+import { createMapMarkerElement } from '~/modules/utils/map/createMapMarkerElement'
 import BaseMap from '../common/BaseMap'
 
 interface PropType {
@@ -47,17 +48,18 @@ export const NearbyStopMap = ({
         datasetLabel: data.label,
         fontSize: '16px',
         fontWeight: 'bold',
+        interactive: true,
         textContent: '🚏',
         type: 'stop'
       })
 
-      const handleSelectStop = (event: MouseEvent) => {
+      const handleSelectStop = (event: MouseEvent | KeyboardEvent) => {
         event.preventDefault()
         event.stopPropagation()
         onSelectStop(data.id)
       }
 
-      el.addEventListener('click', handleSelectStop)
+      addMapMarkerActivationListeners(el, handleSelectStop)
 
       const marker = new Marker({ element: el })
         .setLngLat(data.position)

--- a/app/components/nearby/NearbyStopRoutes.tsx
+++ b/app/components/nearby/NearbyStopRoutes.tsx
@@ -1,10 +1,11 @@
 import { ScrollArea, Skeleton, Stack, Tabs, Text } from '@mantine/core'
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { SkeletonList } from '~/components/common/SkeletonList'
-import { directionMapName } from '~/modules/consts/direction'
 import { DirectionType } from '~/modules/enums/DirectionType'
 import type { StationRoute } from '~/modules/interfaces/StationRoute'
 import { getEnumValues } from '~/modules/utils/getEnumValues'
+import { getDirectionLabel } from '~/modules/utils/getDirectionLabel'
 import { RouteInfoCard } from '../routes/RouteInfoCard'
 
 interface PropType {
@@ -21,10 +22,11 @@ function getDefaultRouteDirection(directions: DirectionType[]) {
 }
 
 export const NearbyStopRoutes = ({ routes, isLoading = false }: PropType) => {
+  const { t } = useTranslation()
   const routeSections = getEnumValues(DirectionType)
     .map((direction) => ({
       direction,
-      label: directionMapName[direction],
+      label: getDirectionLabel(t, direction),
       routes: routes
         .filter((route) => route.direction === direction)
         .sort((left, right) => routeNameCollator.compare(left.name, right.name))
@@ -56,11 +58,11 @@ export const NearbyStopRoutes = ({ routes, isLoading = false }: PropType) => {
   if (isLoading) {
     return (
       <Stack gap="sm" style={{ flex: 1, minHeight: 0 }}>
-        <Text size="sm" c="dimmed">此站路線</Text>
+        <Text size="sm" c="dimmed">{t('components.nearbyStopRoutes.title')}</Text>
         <Tabs value={null}>
           <Tabs.List>
-            <Tabs.Tab value="loading-go">去程</Tabs.Tab>
-            <Tabs.Tab value="loading-return">返程</Tabs.Tab>
+            <Tabs.Tab value="loading-go">{t('common.direction.go')}</Tabs.Tab>
+            <Tabs.Tab value="loading-return">{t('common.direction.return')}</Tabs.Tab>
           </Tabs.List>
         </Tabs>
         <ScrollArea style={{ flex: 1, minHeight: 0 }} data-testid="nearby-stop-routes-skeleton">
@@ -75,15 +77,15 @@ export const NearbyStopRoutes = ({ routes, isLoading = false }: PropType) => {
   if (routeSections.length === 0) {
     return (
       <Stack gap={4}>
-        <Text size="sm" c="dimmed">此站路線</Text>
-        <Text size="sm">目前沒有可顯示的路線資訊</Text>
+        <Text size="sm" c="dimmed">{t('components.nearbyStopRoutes.title')}</Text>
+        <Text size="sm">{t('components.nearbyStopRoutes.empty')}</Text>
       </Stack>
     )
   }
 
   return (
     <Stack gap="sm" style={{ flex: 1, minHeight: 0 }}>
-      <Text size="sm" c="dimmed">此站路線</Text>
+      <Text size="sm" c="dimmed">{t('components.nearbyStopRoutes.title')}</Text>
       <Tabs
         value={selectedDirection}
         onChange={setSelectedDirection}

--- a/app/components/providers/AppI18nProvider.tsx
+++ b/app/components/providers/AppI18nProvider.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type PropsWithChildren } from 'react'
+import { useLocation } from 'react-router'
 import { useSelector } from 'react-redux'
 import { setLocaleInStorage } from '~/modules/i18n/locale'
 import { selectLocale } from '~/modules/slices/localeSlice'
@@ -22,6 +23,7 @@ function syncDocumentMetadata(locale: string) {
 
 export const AppI18nProvider = ({ children }: PropsWithChildren) => {
   const locale = useSelector(selectLocale)
+  const location = useLocation()
 
   useEffect(() => {
     let cancelled = false
@@ -32,7 +34,6 @@ export const AppI18nProvider = ({ children }: PropsWithChildren) => {
       } finally {
         if (cancelled) return
         document.documentElement.lang = locale
-        syncDocumentMetadata(locale)
 
         try {
           setLocaleInStorage(window.localStorage, locale)
@@ -48,6 +49,11 @@ export const AppI18nProvider = ({ children }: PropsWithChildren) => {
       cancelled = true
     }
   }, [locale])
+
+  useEffect(() => {
+    document.documentElement.lang = locale
+    syncDocumentMetadata(locale)
+  }, [locale, location.key])
 
   return children
 }

--- a/app/components/providers/AppI18nProvider.tsx
+++ b/app/components/providers/AppI18nProvider.tsx
@@ -4,17 +4,49 @@ import { setLocaleInStorage } from '~/modules/i18n/locale'
 import { selectLocale } from '~/modules/slices/localeSlice'
 import i18n from '~/modules/i18n'
 
+function syncDocumentMetadata(locale: string) {
+  const t = i18n.getFixedT(locale)
+  document.title = t('app.name')
+
+  const existingMetaDescription = document.querySelector('meta[name="description"]')
+  if (existingMetaDescription) {
+    existingMetaDescription.setAttribute('content', t('app.description'))
+    return
+  }
+
+  const metaDescription = document.createElement('meta')
+  metaDescription.setAttribute('name', 'description')
+  metaDescription.setAttribute('content', t('app.description'))
+  document.head.appendChild(metaDescription)
+}
+
 export const AppI18nProvider = ({ children }: PropsWithChildren) => {
   const locale = useSelector(selectLocale)
 
   useEffect(() => {
-    document.documentElement.lang = locale
-    try {
-      setLocaleInStorage(window.localStorage, locale)
-    } catch {
-      // Ignore storage write failures and keep the in-memory locale.
+    let cancelled = false
+
+    const applyLocale = async () => {
+      try {
+        await i18n.changeLanguage(locale)
+      } finally {
+        if (cancelled) return
+        document.documentElement.lang = locale
+        syncDocumentMetadata(locale)
+
+        try {
+          setLocaleInStorage(window.localStorage, locale)
+        } catch (error) {
+          console.warn('Failed to persist app locale to localStorage.', error)
+        }
+      }
     }
-    void i18n.changeLanguage(locale)
+
+    void applyLocale()
+
+    return () => {
+      cancelled = true
+    }
   }, [locale])
 
   return children

--- a/app/components/routes/RouteInfoCard.tsx
+++ b/app/components/routes/RouteInfoCard.tsx
@@ -1,8 +1,9 @@
 import { Card, Flex, NavLink, Stack, Text } from '@mantine/core'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router'
 import { AppBadge } from '~/components/common/AppBadge'
-import { cityMapName } from '~/modules/consts/city'
 import type { CityNameType } from '~/modules/enums/CityNameType'
+import { getCityLabel } from '~/modules/utils/getCityLabel'
 
 interface PropType {
   to: string
@@ -18,36 +19,40 @@ export const RouteInfoCard = ({
   city,
   departure,
   destination
-}: PropType) => (
-  <Card
-    withBorder
-    radius="md"
-    p="xs"
-    shadow="xs"
-  >
-    <NavLink
-      component={Link}
-      to={to}
-      variant="light"
-      color="blue"
-      px="xs"
-      py={6}
-      bdrs="sm"
-      label={(
-        <Stack gap={8}>
-          <Flex justify="space-between" align="center">
-            <AppBadge type="route">
-              {name}
-            </AppBadge>
-            <AppBadge type="city">
-              {cityMapName[city]}
-            </AppBadge>
-          </Flex>
-          <Text size="xs" c="dimmed">
-            {`起訖站： ${departure} → ${destination}`}
-          </Text>
-        </Stack>
-      )}
-    />
-  </Card>
-)
+}: PropType) => {
+  const { t } = useTranslation()
+
+  return (
+    <Card
+      withBorder
+      radius="md"
+      p="xs"
+      shadow="xs"
+    >
+      <NavLink
+        component={Link}
+        to={to}
+        variant="light"
+        color="blue"
+        px="xs"
+        py={6}
+        bdrs="sm"
+        label={(
+          <Stack gap={8}>
+            <Flex justify="space-between" align="center">
+              <AppBadge type="route">
+                {name}
+              </AppBadge>
+              <AppBadge type="city">
+                {getCityLabel(t, city)}
+              </AppBadge>
+            </Flex>
+            <Text size="xs" c="dimmed">
+              {t('components.routeInfoCard.terminal', { departure, destination })}
+            </Text>
+          </Stack>
+        )}
+      />
+    </Card>
+  )
+}

--- a/app/components/routes/RouteMap.tsx
+++ b/app/components/routes/RouteMap.tsx
@@ -1,6 +1,7 @@
 import type { Map as MapLibreMap, Marker, Popup } from 'maplibre-gl'
 import mapLibre from 'maplibre-gl'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { LngLat, LatLng } from '~/modules/types/CoordsType'
 import { createMapMarkerElement } from '~/modules/utils/createMapMarkerElement'
 import BaseMap from '../common/BaseMap'
@@ -52,6 +53,7 @@ export const RouteMap = ({
   stops,
   vehicles = []
 }: PropType) => {
+  const { t } = useTranslation()
   const [map, setMap] = useState<MapLibreMap | null>(null)
   const [isMapReady, setIsMapReady] = useState(false)
   const markerMap = useRef<Map<string, Marker>>(new Map())
@@ -161,7 +163,11 @@ export const RouteMap = ({
 
     vehicles.forEach((vehicle) => {
       const el = createMapMarkerElement({
-        datasetLabel: `${vehicle.plateNumb ?? '未提供車牌'}\n最近站牌：${vehicle.stopName}\n預估到站：${vehicle.estimateLabel}`,
+        datasetLabel: [
+          vehicle.plateNumb ?? t('components.routeStopList.missingPlate'),
+          `${t('components.routeMap.vehiclePopup.recentStop')}: ${vehicle.stopName}`,
+          `${t('components.routeMap.vehiclePopup.estimate')}: ${vehicle.estimateLabel}`
+        ].join('\n'),
         textContent: '🚌',
         type: 'vehicle'
       })
@@ -213,7 +219,7 @@ export const RouteMap = ({
         duration: 800
       })
     }
-  }, [highlightedStopId, isMapReady, map, onSelectStop, positionedStops, routePath, selectedStop, vehicles])
+  }, [highlightedStopId, isMapReady, map, onSelectStop, positionedStops, routePath, selectedStop, t, vehicles])
 
   useEffect(() => {
     if (!map || !markerMap.current.size) return

--- a/app/components/routes/RouteMap.tsx
+++ b/app/components/routes/RouteMap.tsx
@@ -94,6 +94,7 @@ export const RouteMap = ({
 
   useEffect(() => {
     if (!map || !isMapReady) return
+    const markerCleanupFns: Array<() => void> = []
 
     markerMap.current.forEach((marker) => marker.remove())
     markerMap.current.clear()
@@ -158,7 +159,7 @@ export const RouteMap = ({
         onSelectStop(stop.id)
       }
 
-      addMapMarkerActivationListeners(el, handleSelectStop)
+      markerCleanupFns.push(addMapMarkerActivationListeners(el, handleSelectStop))
 
       const marker = new mapLibre.Marker({ element: el })
         .setLngLat(stop.position)
@@ -211,7 +212,7 @@ export const RouteMap = ({
         })
       }
 
-      addMapMarkerActivationListeners(el, handleOpenVehiclePopup)
+      markerCleanupFns.push(addMapMarkerActivationListeners(el, handleOpenVehiclePopup))
 
       const marker = new mapLibre.Marker({ element: el })
         .setLngLat(vehicle.position)
@@ -231,6 +232,10 @@ export const RouteMap = ({
         maxZoom: 15,
         duration: 800
       })
+    }
+
+    return () => {
+      markerCleanupFns.forEach((cleanup) => cleanup())
     }
   }, [highlightedStopId, isMapReady, map, onSelectStop, positionedStops, routePath, selectedStop, t, vehicles])
 

--- a/app/components/routes/RouteMap.tsx
+++ b/app/components/routes/RouteMap.tsx
@@ -3,7 +3,8 @@ import mapLibre from 'maplibre-gl'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { LngLat, LatLng } from '~/modules/types/CoordsType'
-import { createMapMarkerElement } from '~/modules/utils/createMapMarkerElement'
+import { addMapMarkerActivationListeners } from '~/modules/utils/map/addMapMarkerActivationListeners'
+import { createMapMarkerElement } from '~/modules/utils/map/createMapMarkerElement'
 import BaseMap from '../common/BaseMap'
 
 export interface RouteMapStop {
@@ -145,18 +146,19 @@ export const RouteMap = ({
         }),
         backgroundColor: isHighlighted ? HIGHLIGHTED_STOP_COLOR : ROUTE_COLOR,
         datasetLabel: stop.name,
+        interactive: true,
         textContent: String(stop.sequence),
         title: stop.name,
         type: 'stop'
       })
 
-      const handleSelectStop = (event: MouseEvent) => {
+      const handleSelectStop = (event: MouseEvent | KeyboardEvent) => {
         event.preventDefault()
         event.stopPropagation()
         onSelectStop(stop.id)
       }
 
-      el.addEventListener('click', handleSelectStop)
+      addMapMarkerActivationListeners(el, handleSelectStop)
 
       const marker = new mapLibre.Marker({ element: el })
         .setLngLat(stop.position)
@@ -178,11 +180,12 @@ export const RouteMap = ({
           `${t('components.routeMap.vehiclePopup.recentStop')}: ${vehicle.stopName}`,
           `${t('components.routeMap.vehiclePopup.estimate')}: ${vehicle.estimateLabel}`
         ].join('\n'),
+        interactive: true,
         textContent: '🚌',
         type: 'vehicle'
       })
 
-      const handleOpenVehiclePopup = (event: MouseEvent) => {
+      const handleOpenVehiclePopup = (event: MouseEvent | KeyboardEvent) => {
         event.preventDefault()
         event.stopPropagation()
 
@@ -208,7 +211,7 @@ export const RouteMap = ({
         })
       }
 
-      el.addEventListener('click', handleOpenVehiclePopup)
+      addMapMarkerActivationListeners(el, handleOpenVehiclePopup)
 
       const marker = new mapLibre.Marker({ element: el })
         .setLngLat(vehicle.position)

--- a/app/components/routes/RouteMap.tsx
+++ b/app/components/routes/RouteMap.tsx
@@ -139,6 +139,10 @@ export const RouteMap = ({
     positionedStops.forEach((stop) => {
       const isHighlighted = stop.id === highlightedStopId
       const el = createMapMarkerElement({
+        ariaLabel: t('components.routeMap.stopMarkerAriaLabel', {
+          stopName: stop.name,
+          sequence: stop.sequence
+        }),
         backgroundColor: isHighlighted ? HIGHLIGHTED_STOP_COLOR : ROUTE_COLOR,
         datasetLabel: stop.name,
         textContent: String(stop.sequence),
@@ -162,7 +166,13 @@ export const RouteMap = ({
     })
 
     vehicles.forEach((vehicle) => {
+      const vehicleLabel = t('components.routeMap.vehicleMarkerAriaLabel', {
+        plateNumb: vehicle.plateNumb ?? t('components.routeStopList.missingPlate'),
+        stopName: vehicle.stopName,
+        estimateLabel: vehicle.estimateLabel
+      })
       const el = createMapMarkerElement({
+        ariaLabel: vehicleLabel,
         datasetLabel: [
           vehicle.plateNumb ?? t('components.routeStopList.missingPlate'),
           `${t('components.routeMap.vehiclePopup.recentStop')}: ${vehicle.stopName}`,

--- a/app/components/routes/RouteStopList.tsx
+++ b/app/components/routes/RouteStopList.tsx
@@ -2,7 +2,7 @@ import { ActionIcon, Alert, Badge, Box, Group, ScrollArea, Skeleton, Stack, Text
 import { RiHeart2Fill, RiHeart2Line } from '@remixicon/react'
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { routeRealtimeMessages } from '~/modules/consts/routeRealtimeMessages'
+import { getRouteRealtimeMessages } from '~/modules/consts/routeRealtimeMessages'
 import { RouteRealtimeInfoState } from '~/modules/enums/RouteRealtimeInfoState'
 import { useScrollSelectedItem } from '~/modules/hooks/useScrollSelectedItem'
 import type { FavoriteRouteStop } from '~/modules/interfaces/FavoriteRouteStop'
@@ -48,6 +48,7 @@ export const RouteStopList = ({
 }: PropType) => {
   const { t } = useTranslation()
   const stopItemRefs = useRef<Map<string, HTMLDivElement | null>>(new Map())
+  const routeRealtimeMessages = getRouteRealtimeMessages(t)
 
   useScrollSelectedItem({
     itemElementRefs: stopItemRefs,

--- a/app/modules/apis/errors/busError.test.ts
+++ b/app/modules/apis/errors/busError.test.ts
@@ -4,7 +4,7 @@ import {
   getBusErrorModal,
   getTdxSystemErrorModal,
   getTdxUnauthorizedModal,
-  isTdxRateLimitError,
+  isTdxRateLimitError
 } from './busError'
 
 describe('getTdxHttpErrorStatus', () => {

--- a/app/modules/apis/errors/busError.test.ts
+++ b/app/modules/apis/errors/busError.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   getTdxHttpErrorStatus,
   getBusErrorModal,
+  getTdxSystemErrorModal,
+  getTdxUnauthorizedModal,
   isTdxRateLimitError,
-  tdxSystemErrorModal,
-  tdxUnauthorizedModal
 } from './busError'
 
 describe('getTdxHttpErrorStatus', () => {
@@ -64,7 +64,7 @@ describe('getBusErrorModal', () => {
         status: 401,
         data: {}
       })
-    ).toBe(tdxUnauthorizedModal)
+    ).toEqual(getTdxUnauthorizedModal())
   })
 
   it('returns the unauthorized modal when a 401 is wrapped as a parsing error', () => {
@@ -75,7 +75,7 @@ describe('getBusErrorModal', () => {
         data: 'Unauthorized',
         error: 'SyntaxError: Unexpected token U in JSON at position 0'
       })
-    ).toBe(tdxUnauthorizedModal)
+    ).toEqual(getTdxUnauthorizedModal())
   })
 
   it('does not open a modal for 429 errors', () => {
@@ -104,7 +104,7 @@ describe('getBusErrorModal', () => {
         status: 503,
         data: {}
       })
-    ).toBe(tdxSystemErrorModal)
+    ).toEqual(getTdxSystemErrorModal())
   })
 
   it('returns the system modal for parsing errors from non-auth non-rate-limit responses', () => {
@@ -115,7 +115,7 @@ describe('getBusErrorModal', () => {
         data: '<html>server error</html>',
         error: 'SyntaxError: Unexpected token < in JSON at position 0'
       })
-    ).toBe(tdxSystemErrorModal)
+    ).toEqual(getTdxSystemErrorModal())
   })
 
   it('does not open a modal for fetch errors', () => {

--- a/app/modules/apis/errors/busError.ts
+++ b/app/modules/apis/errors/busError.ts
@@ -1,5 +1,6 @@
 import type { SerializedError } from '@reduxjs/toolkit'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import i18n from '../../i18n'
 import type { OpenGlobalModalPayload } from '../../slices/globalModalSlice'
 
 export enum TdxHttpErrorStatus {
@@ -14,28 +15,26 @@ export enum BaseQueryErrorStatus {
   CUSTOM_ERROR = 'CUSTOM_ERROR'
 }
 
-export const tdxUnauthorizedModal: OpenGlobalModalPayload = {
-  title: '公車資料服務驗證失敗',
-  message: '目前無法驗證公車資料服務，請稍後再試。',
-  variant: 'alert',
-  confirmText: '重整頁面',
-  confirmAction: 'refresh'
+function buildBusErrorModal(key: string): OpenGlobalModalPayload {
+  return {
+    title: i18n.t(`${key}.title`),
+    message: i18n.t(`${key}.description`),
+    variant: 'alert',
+    confirmText: i18n.t('common.modal.refresh'),
+    confirmAction: 'refresh'
+  }
 }
 
-export const tdxRateLimitModal: OpenGlobalModalPayload = {
-  title: '目前查詢人數較多',
-  message: '系統暫時無法取得公車資料，請稍候一段時間再試。',
-  variant: 'alert',
-  confirmText: '重整頁面',
-  confirmAction: 'refresh'
+export function getTdxUnauthorizedModal(): OpenGlobalModalPayload {
+  return buildBusErrorModal('messages.busService.unauthorized')
 }
 
-export const tdxSystemErrorModal: OpenGlobalModalPayload = {
-  title: '系統暫時無法使用',
-  message: '目前無法取得公車資料，請稍後再試。',
-  variant: 'alert',
-  confirmText: '重整頁面',
-  confirmAction: 'refresh'
+export function getTdxRateLimitModal(): OpenGlobalModalPayload {
+  return buildBusErrorModal('messages.busService.rateLimited')
+}
+
+export function getTdxSystemErrorModal(): OpenGlobalModalPayload {
+  return buildBusErrorModal('messages.busService.systemError')
 }
 
 function isFetchBaseQueryError(error: FetchBaseQueryError | SerializedError): error is FetchBaseQueryError {
@@ -74,7 +73,7 @@ export const getBusErrorModal = (error: FetchBaseQueryError) => {
   const tdxHttpStatus = getTdxHttpErrorStatus(error)
 
   if (tdxHttpStatus === TdxHttpErrorStatus.UNAUTHORIZED) {
-    return tdxUnauthorizedModal
+    return getTdxUnauthorizedModal()
   }
 
   if (tdxHttpStatus === TdxHttpErrorStatus.RATE_LIMIT) {
@@ -86,14 +85,14 @@ export const getBusErrorModal = (error: FetchBaseQueryError) => {
     case TdxHttpErrorStatus.RATE_LIMIT:
     case BaseQueryErrorStatus.PARSING_ERROR:
       // A non-JSON or malformed TDX response is effectively a server-side outage.
-      return tdxSystemErrorModal
+      return getTdxSystemErrorModal()
     case BaseQueryErrorStatus.FETCH_ERROR:
     case BaseQueryErrorStatus.TIMEOUT_ERROR:
     case BaseQueryErrorStatus.CUSTOM_ERROR:
       return null
     default:
       if (typeof error.status === 'number' && isTdxSystemStatus(error.status)) {
-        return tdxSystemErrorModal
+        return getTdxSystemErrorModal()
       }
 
       return null

--- a/app/modules/consts/area.test.ts
+++ b/app/modules/consts/area.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { areaMapAreaName, areaMapCity, cityMapArea } from './area'
+import { areaMapCity, areaTranslationKeyMap, cityMapArea } from './area'
 import { AreaType } from '../enums/AreaType'
 import { CityNameType } from '../enums/CityNameType'
 import { getEnumValues } from '../utils/getEnumValues'
@@ -9,7 +9,7 @@ describe('area mappings', () => {
     const areas = getEnumValues(AreaType)
 
     areas.forEach((area) => {
-      expect(areaMapAreaName[area]).toBeTruthy()
+      expect(areaTranslationKeyMap[area]).toBeTruthy()
       expect(areaMapCity[area]).toBeDefined()
       expect(areaMapCity[area]).not.toHaveLength(0)
     })

--- a/app/modules/consts/area.ts
+++ b/app/modules/consts/area.ts
@@ -1,8 +1,8 @@
 import { AreaType } from '../enums/AreaType'
 import { CityNameType } from '../enums/CityNameType'
-import type { zhTW } from '../i18n/locales/zh-TW'
 
-type AreaTranslationKey = `common.area.${keyof typeof zhTW.translation.common.area}`
+type ZhTWLocale = typeof import('../i18n/locales/zh-TW').zhTW
+type AreaTranslationKey = `common.area.${keyof ZhTWLocale['translation']['common']['area']}`
 
 export const areaMapCity: Record<AreaType, CityNameType[]> = {
     [AreaType.TAIPEI]: [CityNameType.TAIPEI, CityNameType.NEW_TAIPEI],

--- a/app/modules/consts/area.ts
+++ b/app/modules/consts/area.ts
@@ -1,6 +1,6 @@
 import { AreaType } from '../enums/AreaType'
 import { CityNameType } from '../enums/CityNameType'
-import { zhTW } from '../i18n/locales/zh-TW'
+import type { zhTW } from '../i18n/locales/zh-TW'
 
 type AreaTranslationKey = `common.area.${keyof typeof zhTW.translation.common.area}`
 

--- a/app/modules/consts/area.ts
+++ b/app/modules/consts/area.ts
@@ -1,5 +1,8 @@
 import { AreaType } from '../enums/AreaType'
 import { CityNameType } from '../enums/CityNameType'
+import { zhTW } from '../i18n/locales/zh-TW'
+
+type AreaTranslationKey = `common.area.${keyof typeof zhTW.translation.common.area}`
 
 export const areaMapCity: Record<AreaType, CityNameType[]> = {
     [AreaType.TAIPEI]: [CityNameType.TAIPEI, CityNameType.NEW_TAIPEI],
@@ -23,26 +26,26 @@ export const areaMapCity: Record<AreaType, CityNameType[]> = {
     [AreaType.LIENCHIANG]: [CityNameType.LIENCHIANG_COUNTY]
 }
 
-export const areaMapAreaName: Record<AreaType, string> = {
-    [AreaType.TAIPEI]: '雙北',
-    [AreaType.TAOYUAN]: '桃園',
-    [AreaType.TAICHUNG]: '台中',
-    [AreaType.TAINAN]: '台南',
-    [AreaType.KAOHSIUNG]: '高雄',
-    [AreaType.KEELUNG]: '基隆',
-    [AreaType.HSINCHU]: '新竹',
-    [AreaType.MIAOLI]: '苗栗',
-    [AreaType.CHANGHUA]: '彰化',
-    [AreaType.NANTOU]: '南投',
-    [AreaType.YUNLIN]: '雲林',
-    [AreaType.CHIAYI]: '嘉義',
-    [AreaType.PINGTUNG]: '屏東',
-    [AreaType.YILAN]: '宜蘭',
-    [AreaType.HUALIEN]: '花蓮',
-    [AreaType.TAITUNG]: '台東',
-    [AreaType.KINMEN]: '金門',
-    [AreaType.PENGHU]: '澎湖',
-    [AreaType.LIENCHIANG]: '連江'
+export const areaTranslationKeyMap: Record<AreaType, AreaTranslationKey> = {
+    [AreaType.TAIPEI]: 'common.area.Taipei',
+    [AreaType.TAOYUAN]: 'common.area.Taoyuan',
+    [AreaType.TAICHUNG]: 'common.area.Taichung',
+    [AreaType.TAINAN]: 'common.area.Tainan',
+    [AreaType.KAOHSIUNG]: 'common.area.Kaohsiung',
+    [AreaType.KEELUNG]: 'common.area.Keelung',
+    [AreaType.HSINCHU]: 'common.area.Hsinchu',
+    [AreaType.MIAOLI]: 'common.area.Miaoli',
+    [AreaType.CHANGHUA]: 'common.area.Changhua',
+    [AreaType.NANTOU]: 'common.area.Nantou',
+    [AreaType.YUNLIN]: 'common.area.Yunlin',
+    [AreaType.CHIAYI]: 'common.area.Chiayi',
+    [AreaType.PINGTUNG]: 'common.area.Pingtung',
+    [AreaType.YILAN]: 'common.area.Yilan',
+    [AreaType.HUALIEN]: 'common.area.Hualien',
+    [AreaType.TAITUNG]: 'common.area.Taitung',
+    [AreaType.KINMEN]: 'common.area.Kinmen',
+    [AreaType.PENGHU]: 'common.area.Penghu',
+    [AreaType.LIENCHIANG]: 'common.area.Lienchiang'
 }
 
 export const cityMapArea = Object.entries(areaMapCity).reduce((result, [area, cities]) => {

--- a/app/modules/consts/city.ts
+++ b/app/modules/consts/city.ts
@@ -1,5 +1,8 @@
 import { CityNameType } from '../enums/CityNameType'
 import { CountyIdType } from '../enums/CountyIdType'
+import { zhTW } from '../i18n/locales/zh-TW'
+
+type CityTranslationKey = `common.city.${keyof typeof zhTW.translation.common.city}`
 
 export const cityMapName: Record<CityNameType, string> = {
   [CityNameType.TAIPEI]: '台北市',
@@ -24,6 +27,31 @@ export const cityMapName: Record<CityNameType, string> = {
   [CityNameType.KINMEN_COUNTY]: '金門縣',
   [CityNameType.PENGHU_COUNTY]: '澎湖縣',
   [CityNameType.LIENCHIANG_COUNTY]: '連江縣'
+}
+
+export const cityTranslationKeyMap: Record<CityNameType, CityTranslationKey> = {
+  [CityNameType.TAIPEI]: 'common.city.Taipei',
+  [CityNameType.NEW_TAIPEI]: 'common.city.NewTaipei',
+  [CityNameType.TAOYUAN]: 'common.city.Taoyuan',
+  [CityNameType.TAICHUNG]: 'common.city.Taichung',
+  [CityNameType.TAINAN]: 'common.city.Tainan',
+  [CityNameType.KAOHSIUNG]: 'common.city.Kaohsiung',
+  [CityNameType.KEELUNG]: 'common.city.Keelung',
+  [CityNameType.HSINCHU]: 'common.city.Hsinchu',
+  [CityNameType.HSINCHU_COUNTY]: 'common.city.HsinchuCounty',
+  [CityNameType.MIAOLI_COUNTY]: 'common.city.MiaoliCounty',
+  [CityNameType.CHANGHUA_COUNTY]: 'common.city.ChanghuaCounty',
+  [CityNameType.NANTOU_COUNTY]: 'common.city.NantouCounty',
+  [CityNameType.YUNLIN_COUNTY]: 'common.city.YunlinCounty',
+  [CityNameType.CHIAYI_COUNTY]: 'common.city.ChiayiCounty',
+  [CityNameType.CHIAYI]: 'common.city.Chiayi',
+  [CityNameType.PINGTUNG_COUNTY]: 'common.city.PingtungCounty',
+  [CityNameType.YILAN_COUNTY]: 'common.city.YilanCounty',
+  [CityNameType.HUALIEN_COUNTY]: 'common.city.HualienCounty',
+  [CityNameType.TAITUNG_COUNTY]: 'common.city.TaitungCounty',
+  [CityNameType.KINMEN_COUNTY]: 'common.city.KinmenCounty',
+  [CityNameType.PENGHU_COUNTY]: 'common.city.PenghuCounty',
+  [CityNameType.LIENCHIANG_COUNTY]: 'common.city.LienchiangCounty'
 }
 
 export const cityMapNameToCity = Object.fromEntries(

--- a/app/modules/consts/city.ts
+++ b/app/modules/consts/city.ts
@@ -1,6 +1,6 @@
 import { CityNameType } from '../enums/CityNameType'
 import { CountyIdType } from '../enums/CountyIdType'
-import { zhTW } from '../i18n/locales/zh-TW'
+import type { zhTW } from '../i18n/locales/zh-TW'
 
 type CityTranslationKey = `common.city.${keyof typeof zhTW.translation.common.city}`
 

--- a/app/modules/consts/city.ts
+++ b/app/modules/consts/city.ts
@@ -1,8 +1,8 @@
 import { CityNameType } from '../enums/CityNameType'
 import { CountyIdType } from '../enums/CountyIdType'
-import type { zhTW } from '../i18n/locales/zh-TW'
 
-type CityTranslationKey = `common.city.${keyof typeof zhTW.translation.common.city}`
+type ZhTWLocale = typeof import('../i18n/locales/zh-TW').zhTW
+type CityTranslationKey = `common.city.${keyof ZhTWLocale['translation']['common']['city']}`
 
 export const cityMapName: Record<CityNameType, string> = {
   [CityNameType.TAIPEI]: '台北市',

--- a/app/modules/consts/direction.ts
+++ b/app/modules/consts/direction.ts
@@ -1,7 +1,7 @@
 import { DirectionType } from '../enums/DirectionType'
-import type { zhTW } from '../i18n/locales/zh-TW'
 
-type DirectionTranslationKey = `common.direction.${keyof typeof zhTW.translation.common.direction}`
+type ZhTWLocale = typeof import('../i18n/locales/zh-TW').zhTW
+type DirectionTranslationKey = `common.direction.${keyof ZhTWLocale['translation']['common']['direction']}`
 
 export const directionTranslationKeyMap: Record<DirectionType, DirectionTranslationKey> = {
   [DirectionType.GO]: 'common.direction.go',

--- a/app/modules/consts/direction.ts
+++ b/app/modules/consts/direction.ts
@@ -1,5 +1,5 @@
 import { DirectionType } from '../enums/DirectionType'
-import { zhTW } from '../i18n/locales/zh-TW'
+import type { zhTW } from '../i18n/locales/zh-TW'
 
 type DirectionTranslationKey = `common.direction.${keyof typeof zhTW.translation.common.direction}`
 

--- a/app/modules/consts/direction.ts
+++ b/app/modules/consts/direction.ts
@@ -1,9 +1,12 @@
 import { DirectionType } from '../enums/DirectionType'
+import { zhTW } from '../i18n/locales/zh-TW'
 
-export const directionMapName: Record<DirectionType, string> = {
-  [DirectionType.GO]: '去程',
-  [DirectionType.RETURN]: '返程',
-  [DirectionType.LOOP]: '迴圈',
-  [DirectionType.SHUTTLE]: '循環',
-  [DirectionType.UNKNOWN]: '未知'
+type DirectionTranslationKey = `common.direction.${keyof typeof zhTW.translation.common.direction}`
+
+export const directionTranslationKeyMap: Record<DirectionType, DirectionTranslationKey> = {
+  [DirectionType.GO]: 'common.direction.go',
+  [DirectionType.RETURN]: 'common.direction.return',
+  [DirectionType.LOOP]: 'common.direction.loop',
+  [DirectionType.SHUTTLE]: 'common.direction.shuttle',
+  [DirectionType.UNKNOWN]: 'common.direction.unknown'
 }

--- a/app/modules/consts/routeRealtimeMessages.ts
+++ b/app/modules/consts/routeRealtimeMessages.ts
@@ -1,27 +1,35 @@
-export const routeRealtimeMessages = {
-  loading: {
-    color: 'gray',
-    title: '更新中',
-    description: '正在更新線上公車資料...'
-  },
-  error: {
-    color: 'orange',
-    title: '即時公車',
-    description: '即時公車資料暫時無法完整更新。'
-  },
-  rateLimited: {
-    color: 'orange',
-    title: '即時公車',
-    description: '目前同時查詢人數較多，即時公車資料會稍後自動重試。'
-  },
-  noService: {
-    color: 'blue',
-    title: '營運狀態',
-    description: '目前沒有營運班次'
-  },
-  noRealtimeData: {
-    color: 'yellow',
-    title: '即時公車',
-    description: '目前沒有可顯示的即時公車資訊，可能是已收班或上游暫時未提供完整資料。'
+import type { TFunction } from 'i18next'
+import { RouteRealtimeInfoState } from '../enums/RouteRealtimeInfoState'
+
+interface RouteRealtimeMessage {
+  color: string
+  title: string
+  description: string
+}
+
+interface RouteRealtimeMessages {
+  loading: RouteRealtimeMessage
+  error: RouteRealtimeMessage
+  rateLimited: RouteRealtimeMessage
+  noService: RouteRealtimeMessage
+  noRealtimeData: RouteRealtimeMessage
+}
+
+function buildRouteRealtimeMessage(t: TFunction, color: string, key: string): RouteRealtimeMessage {
+  return {
+    color,
+    title: t(`${key}.title`),
+    description: t(`${key}.description`)
   }
-} as const
+}
+
+export function getRouteRealtimeMessages(t: TFunction): RouteRealtimeMessages &
+Record<RouteRealtimeInfoState.NO_SERVICE | RouteRealtimeInfoState.NO_REALTIME_DATA, RouteRealtimeMessage> {
+  return {
+    loading: buildRouteRealtimeMessage(t, 'gray', 'messages.routeRealtime.loading'),
+    error: buildRouteRealtimeMessage(t, 'orange', 'messages.routeRealtime.error'),
+    rateLimited: buildRouteRealtimeMessage(t, 'orange', 'messages.routeRealtime.rateLimited'),
+    noService: buildRouteRealtimeMessage(t, 'blue', 'messages.routeRealtime.noService'),
+    noRealtimeData: buildRouteRealtimeMessage(t, 'yellow', 'messages.routeRealtime.noRealtimeData')
+  }
+}

--- a/app/modules/consts/stopStatus.ts
+++ b/app/modules/consts/stopStatus.ts
@@ -1,7 +1,8 @@
 import { StopStatusType } from '../enums/StopStatusType'
-import type { zhTW } from '../i18n/locales/zh-TW'
 
-type StopStatusTranslationKey = `routePage.realtime.stopStatus.${keyof typeof zhTW.translation.routePage.realtime.stopStatus}`
+type ZhTWLocale = typeof import('../i18n/locales/zh-TW').zhTW
+type StopStatusTranslationKey =
+  `routePage.realtime.stopStatus.${keyof ZhTWLocale['translation']['routePage']['realtime']['stopStatus']}`
 
 export const stopStatusTranslationKeyMap: Record<StopStatusType, StopStatusTranslationKey> = {
   [StopStatusType.NORMAL]: 'routePage.realtime.stopStatus.normal',

--- a/app/modules/consts/stopStatus.ts
+++ b/app/modules/consts/stopStatus.ts
@@ -1,5 +1,5 @@
 import { StopStatusType } from '../enums/StopStatusType'
-import { zhTW } from '../i18n/locales/zh-TW'
+import type { zhTW } from '../i18n/locales/zh-TW'
 
 type StopStatusTranslationKey = `routePage.realtime.stopStatus.${keyof typeof zhTW.translation.routePage.realtime.stopStatus}`
 

--- a/app/modules/consts/stopStatus.ts
+++ b/app/modules/consts/stopStatus.ts
@@ -1,10 +1,13 @@
 import { StopStatusType } from '../enums/StopStatusType'
+import { zhTW } from '../i18n/locales/zh-TW'
 
-export const stopStatusMapLabel: Record<StopStatusType, string> = {
-  [StopStatusType.NORMAL]: '正常',
-  [StopStatusType.NOT_YET_DEPARTED]: '- 分後到站',
-  [StopStatusType.NO_STOP_DUE_TO_TRAFFIC_CONTROL]: '交管不停靠',
-  [StopStatusType.LAST_BUS_PASSED]: '末班已過',
-  [StopStatusType.NOT_IN_SERVICE_TODAY]: '今日未營運',
-  [StopStatusType.UNKNOWN]: '未知狀態'
+type StopStatusTranslationKey = `routePage.realtime.stopStatus.${keyof typeof zhTW.translation.routePage.realtime.stopStatus}`
+
+export const stopStatusTranslationKeyMap: Record<StopStatusType, StopStatusTranslationKey> = {
+  [StopStatusType.NORMAL]: 'routePage.realtime.stopStatus.normal',
+  [StopStatusType.NOT_YET_DEPARTED]: 'routePage.realtime.stopStatus.notYetDeparted',
+  [StopStatusType.NO_STOP_DUE_TO_TRAFFIC_CONTROL]: 'routePage.realtime.stopStatus.noStopDueToTrafficControl',
+  [StopStatusType.LAST_BUS_PASSED]: 'routePage.realtime.stopStatus.lastBusPassed',
+  [StopStatusType.NOT_IN_SERVICE_TODAY]: 'routePage.realtime.stopStatus.notInServiceToday',
+  [StopStatusType.UNKNOWN]: 'routePage.realtime.stopStatus.unknown'
 }

--- a/app/modules/hooks/useRouteBaseData.ts
+++ b/app/modules/hooks/useRouteBaseData.ts
@@ -1,13 +1,13 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { busApi } from '~/modules/apis/bus'
-import { directionMapName } from '~/modules/consts/direction'
 import { getRouteMessages } from '~/modules/consts/pageMessages'
 import type { CityNameType } from '~/modules/enums/CityNameType'
 import { DirectionType } from '~/modules/enums/DirectionType'
 import type { BusSubRoute } from '~/modules/interfaces/BusRoute'
 import type { FavoriteRouteStop } from '~/modules/interfaces/FavoriteRouteStop'
 import type { StopOfRouteStop } from '~/modules/interfaces/StopOfRoute'
+import { getDirectionLabel } from '~/modules/utils/getDirectionLabel'
 import { normalizeBusRoutesWithDates } from '~/modules/utils/normalizeBusRoutesWithDates'
 
 export interface RouteTab {
@@ -84,7 +84,7 @@ export function useRouteBaseData({
       id: `${subRoute.SubRouteUID}-${subRoute.Direction}`,
       label: [
         subRoute.SubRouteName.zh_TW.trim() === routeName ? null : subRoute.SubRouteName.zh_TW.trim(),
-        directionMapName[subRoute.Direction]
+        getDirectionLabel(t, subRoute.Direction)
       ].filter(Boolean).join(' '),
       subRouteUID: subRoute.SubRouteUID,
       direction: subRoute.Direction

--- a/app/modules/hooks/useRouteRealtimeData.ts
+++ b/app/modules/hooks/useRouteRealtimeData.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { busApi } from '~/modules/apis/bus'
 import { isTdxRateLimitError } from '~/modules/apis/errors/busError'
 import type { BusRoute, BusSubRoute } from '~/modules/interfaces/BusRoute'
@@ -25,6 +26,7 @@ export function useRouteRealtimeData({
   city,
   id
 }: UseRouteRealtimeDataOptions) {
+  const { t } = useTranslation()
   const cityName = city as CityNameType
   const shouldPrepareRealtimeQueries = Boolean(city && id && busRoute && activeSubRoute)
   const [realtimeStartDelayMs, setRealtimeStartDelayMs] = useState<number | null>(null)
@@ -130,9 +132,10 @@ export function useRouteRealtimeData({
   ), [activeSubRoute, realtimeNearStops])
 
   const realtimeBusStatuses = useMemo(() => getRouteRealtimeBusStatuses(
+    t,
     activeRealtimeNearStops,
     activeEstimatedArrivals
-  ), [activeEstimatedArrivals, activeRealtimeNearStops])
+  ), [activeEstimatedArrivals, activeRealtimeNearStops, t])
 
   const realtimeBusesByStopSequence = useMemo(() => {
     return realtimeBusStatuses.reduce<Map<number, typeof realtimeBusStatuses>>((result, realtimeBus) => {
@@ -158,6 +161,7 @@ export function useRouteRealtimeData({
 
     return sortedEstimatedArrivals.reduce<Map<string, string>>((result, estimatedArrival) => {
       const estimatedArrivalLabel = formatEstimatedArrivalLabel(
+        t,
         estimatedArrival.EstimateTime,
         estimatedArrival.StopStatus
       )
@@ -172,7 +176,7 @@ export function useRouteRealtimeData({
 
       return result
     }, new Map())
-  }, [activeEstimatedArrivals])
+  }, [activeEstimatedArrivals, t])
 
   const hasRealtimeError = useMemo(() => {
     if (isEstimatedArrivalsError && estimatedArrivals.length === 0) {

--- a/app/modules/i18n/locales/en.ts
+++ b/app/modules/i18n/locales/en.ts
@@ -165,6 +165,15 @@ export const en = {
         }
       }
     },
+    errorBoundary: {
+      default: {
+        title: 'Error'
+      },
+      notFound: {
+        title: '404',
+        description: 'The requested page could not be found.'
+      }
+    },
     messages: {
       nearby: {
         loadStopsError: {

--- a/app/modules/i18n/locales/en.ts
+++ b/app/modules/i18n/locales/en.ts
@@ -5,6 +5,32 @@ export const en = {
       description: 'Find the bus you need, faster.'
     },
     common: {
+      modal: {
+        confirm: 'Confirm',
+        cancel: 'Cancel',
+        refresh: 'Refresh page'
+      },
+      area: {
+        Taipei: 'Taipei and New Taipei',
+        Taoyuan: 'Taoyuan',
+        Taichung: 'Taichung',
+        Tainan: 'Tainan',
+        Kaohsiung: 'Kaohsiung',
+        Keelung: 'Keelung',
+        Hsinchu: 'Hsinchu',
+        Miaoli: 'Miaoli',
+        Changhua: 'Changhua',
+        Nantou: 'Nantou',
+        Yunlin: 'Yunlin',
+        Chiayi: 'Chiayi',
+        Pingtung: 'Pingtung',
+        Yilan: 'Yilan',
+        Hualien: 'Hualien',
+        Taitung: 'Taitung',
+        Kinmen: 'Kinmen',
+        Penghu: 'Penghu',
+        Lienchiang: 'Lienchiang'
+      },
       city: {
         Taipei: 'Taipei City',
         NewTaipei: 'New Taipei City',
@@ -84,6 +110,12 @@ export const en = {
         removeFavoriteAriaLabel: 'Remove saved route stop',
         missingPlate: 'Plate unavailable'
       },
+      routeMap: {
+        vehiclePopup: {
+          recentStop: 'Recent stop',
+          estimate: 'Estimated arrival'
+        }
+      },
       mapSidebarLayout: {
         openNearbyStops: 'Open nearby stops list',
         openRouteList: 'Open route list'
@@ -104,7 +136,22 @@ export const en = {
       }
     },
     routePage: {
-      backToRoutes: 'Back to routes'
+      backToRoutes: 'Back to routes',
+      realtime: {
+        inService: 'In service',
+        comingSoon: 'Coming soon',
+        noEstimate: 'No estimate available',
+        minutesAway_one: 'Arriving in {{count}} min',
+        minutesAway_other: 'Arriving in {{count}} mins',
+        stopStatus: {
+          normal: 'Normal',
+          notYetDeparted: 'Not departed yet',
+          noStopDueToTrafficControl: 'Skipping stop due to traffic control',
+          lastBusPassed: 'Last bus has passed',
+          notInServiceToday: 'Not in service today',
+          unknown: 'Unknown status'
+        }
+      }
     },
     messages: {
       nearby: {
@@ -141,6 +188,42 @@ export const en = {
         emptyRoute: {
           title: 'Route not found',
           description: 'We could not find data for this bus route.'
+        }
+      },
+      routeRealtime: {
+        loading: {
+          title: 'Updating',
+          description: 'Refreshing realtime bus data...'
+        },
+        error: {
+          title: 'Realtime bus',
+          description: 'Realtime bus data is temporarily incomplete.'
+        },
+        rateLimited: {
+          title: 'Realtime bus',
+          description: 'Too many people are querying right now. Realtime bus data will retry shortly.'
+        },
+        noService: {
+          title: 'Service status',
+          description: 'There are no active services right now'
+        },
+        noRealtimeData: {
+          title: 'Realtime bus',
+          description: 'No realtime bus information is available right now. Service may have ended or upstream data may be temporarily incomplete.'
+        }
+      },
+      busService: {
+        unauthorized: {
+          title: 'Bus data service authentication failed',
+          description: 'The app could not authenticate with the bus data service right now. Please try again later.'
+        },
+        rateLimited: {
+          title: 'Too many queries right now',
+          description: 'The system cannot fetch bus data at the moment. Please wait a bit and try again.'
+        },
+        systemError: {
+          title: 'The system is temporarily unavailable',
+          description: 'Bus data is temporarily unavailable. Please try again later.'
         }
       },
       geo: {

--- a/app/modules/i18n/locales/en.ts
+++ b/app/modules/i18n/locales/en.ts
@@ -4,6 +4,39 @@ export const en = {
       name: 'Finding the Bus',
       description: 'Find the bus you need, faster.'
     },
+    common: {
+      city: {
+        Taipei: 'Taipei City',
+        NewTaipei: 'New Taipei City',
+        Taoyuan: 'Taoyuan City',
+        Taichung: 'Taichung City',
+        Tainan: 'Tainan City',
+        Kaohsiung: 'Kaohsiung City',
+        Keelung: 'Keelung City',
+        Hsinchu: 'Hsinchu City',
+        HsinchuCounty: 'Hsinchu County',
+        MiaoliCounty: 'Miaoli County',
+        ChanghuaCounty: 'Changhua County',
+        NantouCounty: 'Nantou County',
+        YunlinCounty: 'Yunlin County',
+        ChiayiCounty: 'Chiayi County',
+        Chiayi: 'Chiayi City',
+        PingtungCounty: 'Pingtung County',
+        YilanCounty: 'Yilan County',
+        HualienCounty: 'Hualien County',
+        TaitungCounty: 'Taitung County',
+        KinmenCounty: 'Kinmen County',
+        PenghuCounty: 'Penghu County',
+        LienchiangCounty: 'Lienchiang County'
+      },
+      direction: {
+        go: 'Outbound',
+        return: 'Inbound',
+        loop: 'Loop',
+        shuttle: 'Shuttle',
+        unknown: 'Unknown'
+      }
+    },
     layout: {
       nav: {
         favorite: 'Favorites',
@@ -43,6 +76,9 @@ export const en = {
         terminalLabel: 'Terminals',
         terminal: '{{departure}} → {{destination}}'
       },
+      routeInfoCard: {
+        terminal: 'Terminals: {{departure}} → {{destination}}'
+      },
       routeStopList: {
         addFavoriteAriaLabel: 'Save route stop',
         removeFavoriteAriaLabel: 'Remove saved route stop',
@@ -58,6 +94,10 @@ export const en = {
         routesLabel: 'Routes',
         notProvided: 'Not provided',
         viewRoutesAriaLabel: 'View routes for {{stopName}}'
+      },
+      nearbyStopRoutes: {
+        title: 'Routes at this stop',
+        empty: 'No route information is currently available for this stop'
       },
       nearbySidebarContent: {
         backAriaLabel: 'Back to nearby stops list'

--- a/app/modules/i18n/locales/en.ts
+++ b/app/modules/i18n/locales/en.ts
@@ -95,7 +95,11 @@ export const en = {
     components: {
       searchInput: {
         ariaLabel: 'Search bus routes',
-        placeholder: 'Search by route, departure stop, or destination'
+        placeholder: 'Search by route, departure stop, or destination',
+        clearAriaLabel: 'Clear search keyword'
+      },
+      areaSelect: {
+        ariaLabel: 'Choose area'
       },
       favoriteRouteStopCard: {
         removeAriaLabel: 'Remove favorite route stop',
@@ -111,10 +115,15 @@ export const en = {
         missingPlate: 'Plate unavailable'
       },
       routeMap: {
+        stopMarkerAriaLabel: '{{stopName}}, stop {{sequence}}',
+        vehicleMarkerAriaLabel: '{{plateNumb}}, recent stop {{stopName}}, estimated arrival {{estimateLabel}}',
         vehiclePopup: {
           recentStop: 'Recent stop',
           estimate: 'Estimated arrival'
         }
+      },
+      baseMap: {
+        userLocationMarkerAriaLabel: 'Current location'
       },
       mapSidebarLayout: {
         openNearbyStops: 'Open nearby stops list',
@@ -130,6 +139,9 @@ export const en = {
       nearbyStopRoutes: {
         title: 'Routes at this stop',
         empty: 'No route information is currently available for this stop'
+      },
+      nearbyStopMap: {
+        stopMarkerAriaLabel: 'Nearby stop {{stopName}}'
       },
       nearbySidebarContent: {
         backAriaLabel: 'Back to nearby stops list'

--- a/app/modules/i18n/locales/en.ts
+++ b/app/modules/i18n/locales/en.ts
@@ -11,7 +11,7 @@ export const en = {
         refresh: 'Refresh page'
       },
       area: {
-        Taipei: 'Taipei and New Taipei',
+        Taipei: 'Taipei Area',
         Taoyuan: 'Taoyuan',
         Taichung: 'Taichung',
         Tainan: 'Tainan',
@@ -95,7 +95,7 @@ export const en = {
     components: {
       searchInput: {
         ariaLabel: 'Search bus routes',
-        placeholder: 'Search by route, departure stop, or destination',
+        placeholder: 'Search routes or stops',
         clearAriaLabel: 'Clear search keyword'
       },
       areaSelect: {

--- a/app/modules/i18n/locales/zh-TW.ts
+++ b/app/modules/i18n/locales/zh-TW.ts
@@ -165,6 +165,15 @@ export const zhTW = {
         }
       }
     },
+    errorBoundary: {
+      default: {
+        title: '發生錯誤'
+      },
+      notFound: {
+        title: '404',
+        description: '找不到你要的頁面。'
+      }
+    },
     messages: {
       nearby: {
         loadStopsError: {

--- a/app/modules/i18n/locales/zh-TW.ts
+++ b/app/modules/i18n/locales/zh-TW.ts
@@ -95,7 +95,11 @@ export const zhTW = {
     components: {
       searchInput: {
         ariaLabel: '搜尋公車路線',
-        placeholder: '輸入關鍵字以搜尋路線、起點或終點'
+        placeholder: '輸入關鍵字以搜尋路線、起點或終點',
+        clearAriaLabel: '清除搜尋關鍵字'
+      },
+      areaSelect: {
+        ariaLabel: '選擇區域'
       },
       favoriteRouteStopCard: {
         removeAriaLabel: '移除收藏站牌路線',
@@ -111,10 +115,15 @@ export const zhTW = {
         missingPlate: '未提供車牌'
       },
       routeMap: {
+        stopMarkerAriaLabel: '{{stopName}}，第 {{sequence}} 站',
+        vehicleMarkerAriaLabel: '{{plateNumb}}，最近站牌 {{stopName}}，預估到站 {{estimateLabel}}',
         vehiclePopup: {
           recentStop: '最近站牌',
           estimate: '預估到站'
         }
+      },
+      baseMap: {
+        userLocationMarkerAriaLabel: '目前位置'
       },
       mapSidebarLayout: {
         openNearbyStops: '開啟附近站牌列表',
@@ -130,6 +139,9 @@ export const zhTW = {
       nearbyStopRoutes: {
         title: '此站路線',
         empty: '目前沒有可顯示的路線資訊'
+      },
+      nearbyStopMap: {
+        stopMarkerAriaLabel: '附近站牌 {{stopName}}'
       },
       nearbySidebarContent: {
         backAriaLabel: '返回附近站牌列表'

--- a/app/modules/i18n/locales/zh-TW.ts
+++ b/app/modules/i18n/locales/zh-TW.ts
@@ -4,6 +4,39 @@ export const zhTW = {
       name: 'Finding the Bus',
       description: '一起找公車。'
     },
+    common: {
+      city: {
+        Taipei: '台北市',
+        NewTaipei: '新北市',
+        Taoyuan: '桃園市',
+        Taichung: '台中市',
+        Tainan: '台南市',
+        Kaohsiung: '高雄市',
+        Keelung: '基隆市',
+        Hsinchu: '新竹市',
+        HsinchuCounty: '新竹縣',
+        MiaoliCounty: '苗栗縣',
+        ChanghuaCounty: '彰化縣',
+        NantouCounty: '南投縣',
+        YunlinCounty: '雲林縣',
+        ChiayiCounty: '嘉義縣',
+        Chiayi: '嘉義市',
+        PingtungCounty: '屏東縣',
+        YilanCounty: '宜蘭縣',
+        HualienCounty: '花蓮縣',
+        TaitungCounty: '台東縣',
+        KinmenCounty: '金門縣',
+        PenghuCounty: '澎湖縣',
+        LienchiangCounty: '連江縣'
+      },
+      direction: {
+        go: '去程',
+        return: '返程',
+        loop: '迴圈',
+        shuttle: '循環',
+        unknown: '未知'
+      }
+    },
     layout: {
       nav: {
         favorite: '我的最愛',
@@ -43,6 +76,9 @@ export const zhTW = {
         terminalLabel: '起訖站',
         terminal: '{{departure}} → {{destination}}'
       },
+      routeInfoCard: {
+        terminal: '起訖站： {{departure}} → {{destination}}'
+      },
       routeStopList: {
         addFavoriteAriaLabel: '收藏站牌路線',
         removeFavoriteAriaLabel: '取消收藏站牌路線',
@@ -58,6 +94,10 @@ export const zhTW = {
         routesLabel: '路線',
         notProvided: '未提供',
         viewRoutesAriaLabel: '查看 {{stopName}} 路線'
+      },
+      nearbyStopRoutes: {
+        title: '此站路線',
+        empty: '目前沒有可顯示的路線資訊'
       },
       nearbySidebarContent: {
         backAriaLabel: '返回附近站牌列表'

--- a/app/modules/i18n/locales/zh-TW.ts
+++ b/app/modules/i18n/locales/zh-TW.ts
@@ -5,6 +5,32 @@ export const zhTW = {
       description: '一起找公車。'
     },
     common: {
+      modal: {
+        confirm: '確定',
+        cancel: '取消',
+        refresh: '重整頁面'
+      },
+      area: {
+        Taipei: '雙北',
+        Taoyuan: '桃園',
+        Taichung: '台中',
+        Tainan: '台南',
+        Kaohsiung: '高雄',
+        Keelung: '基隆',
+        Hsinchu: '新竹',
+        Miaoli: '苗栗',
+        Changhua: '彰化',
+        Nantou: '南投',
+        Yunlin: '雲林',
+        Chiayi: '嘉義',
+        Pingtung: '屏東',
+        Yilan: '宜蘭',
+        Hualien: '花蓮',
+        Taitung: '台東',
+        Kinmen: '金門',
+        Penghu: '澎湖',
+        Lienchiang: '連江'
+      },
       city: {
         Taipei: '台北市',
         NewTaipei: '新北市',
@@ -84,6 +110,12 @@ export const zhTW = {
         removeFavoriteAriaLabel: '取消收藏站牌路線',
         missingPlate: '未提供車牌'
       },
+      routeMap: {
+        vehiclePopup: {
+          recentStop: '最近站牌',
+          estimate: '預估到站'
+        }
+      },
       mapSidebarLayout: {
         openNearbyStops: '開啟附近站牌列表',
         openRouteList: '開啟路線列表'
@@ -104,7 +136,22 @@ export const zhTW = {
       }
     },
     routePage: {
-      backToRoutes: '返回路線列表'
+      backToRoutes: '返回路線列表',
+      realtime: {
+        inService: '行駛中',
+        comingSoon: '即將進站',
+        noEstimate: '暫無預估',
+        minutesAway_one: '{{count}} 分後到站',
+        minutesAway_other: '{{count}} 分後到站',
+        stopStatus: {
+          normal: '正常',
+          notYetDeparted: '- 分後到站',
+          noStopDueToTrafficControl: '交管不停靠',
+          lastBusPassed: '末班已過',
+          notInServiceToday: '今日未營運',
+          unknown: '未知狀態'
+        }
+      }
     },
     messages: {
       nearby: {
@@ -141,6 +188,42 @@ export const zhTW = {
         emptyRoute: {
           title: '查無路線',
           description: '目前找不到這條公車路線資料。'
+        }
+      },
+      routeRealtime: {
+        loading: {
+          title: '更新中',
+          description: '正在更新線上公車資料...'
+        },
+        error: {
+          title: '即時公車',
+          description: '即時公車資料暫時無法完整更新。'
+        },
+        rateLimited: {
+          title: '即時公車',
+          description: '目前同時查詢人數較多，即時公車資料會稍後自動重試。'
+        },
+        noService: {
+          title: '營運狀態',
+          description: '目前沒有營運班次'
+        },
+        noRealtimeData: {
+          title: '即時公車',
+          description: '目前沒有可顯示的即時公車資訊，可能是已收班或上游暫時未提供完整資料。'
+        }
+      },
+      busService: {
+        unauthorized: {
+          title: '公車資料服務驗證失敗',
+          description: '目前無法驗證公車資料服務，請稍後再試。'
+        },
+        rateLimited: {
+          title: '目前查詢人數較多',
+          description: '系統暫時無法取得公車資料，請稍候一段時間再試。'
+        },
+        systemError: {
+          title: '系統暫時無法使用',
+          description: '目前無法取得公車資料，請稍後再試。'
         }
       },
       geo: {

--- a/app/modules/i18n/locales/zh-TW.ts
+++ b/app/modules/i18n/locales/zh-TW.ts
@@ -95,7 +95,7 @@ export const zhTW = {
     components: {
       searchInput: {
         ariaLabel: '搜尋公車路線',
-        placeholder: '輸入關鍵字以搜尋路線、起點或終點',
+        placeholder: '搜尋路線、起點或終點',
         clearAriaLabel: '清除搜尋關鍵字'
       },
       areaSelect: {

--- a/app/modules/slices/cityGeoSlice.ts
+++ b/app/modules/slices/cityGeoSlice.ts
@@ -42,21 +42,21 @@ export const fetchCityGeoJSON = () => async (dispatch: AppDispatch) => {
   try {
     const url = 'https://cdn.jsdelivr.net/npm/taiwan-atlas/counties-10t.json'
     const res = await fetch(url)
-    if (!res.ok) throw new Error('API 取得失敗')
+    if (!res.ok) throw new Error('Failed to fetch city GeoJSON API.')
     const topo: Topology = await res.json()
     const geo = feature(topo, topo.objects.counties)
     if (geo.type === 'FeatureCollection') {
       dispatch(setGeoJSON(geo))
       localStorage.setItem('cityGeoJSON', JSON.stringify(geo))
     } else {
-      throw new Error('取得的 TopoJSON 不是 FeatureCollection')
+      throw new Error('Fetched TopoJSON is not a FeatureCollection.')
     }
   } catch (err) {
     console.error('fetchCityGeoJSON error:', err)
     const backup = localStorage.getItem('cityGeoJSON')
     if (backup) {
       dispatch(setGeoJSON(JSON.parse(backup)))
-      dispatch(setError('API 取得失敗，已使用備份資料'))
+      dispatch(setError('Failed to fetch city GeoJSON API. Using cached backup data.'))
     }
   }
 }

--- a/app/modules/slices/globalModalSlice.test.ts
+++ b/app/modules/slices/globalModalSlice.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   getTdxRateLimitModal,
   getTdxSystemErrorModal
@@ -10,6 +10,10 @@ import globalModalSlice, {
 } from './globalModalSlice'
 
 describe('globalModalSlice', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('zh-TW')
+  })
+
   it('stores modal content and confirm behavior when opened', () => {
     const tdxRateLimitModal = getTdxRateLimitModal()
     const state = globalModalSlice.reducer(
@@ -43,5 +47,18 @@ describe('globalModalSlice', () => {
       cancelText: i18n.t('common.modal.cancel'),
       confirmAction: 'close'
     })
+  })
+
+  it('uses the current locale for default modal button labels', async () => {
+    await i18n.changeLanguage('en')
+
+    const state = globalModalSlice.reducer(undefined, openGlobalModal({
+      title: 'title',
+      message: 'message',
+      variant: 'alert'
+    }))
+
+    expect(state.confirmText).toBe(i18n.t('common.modal.confirm'))
+    expect(state.cancelText).toBe(i18n.t('common.modal.cancel'))
   })
 })

--- a/app/modules/slices/globalModalSlice.test.ts
+++ b/app/modules/slices/globalModalSlice.test.ts
@@ -24,7 +24,7 @@ describe('globalModalSlice', () => {
     expect(state).toMatchObject({
       opened: true,
       ...tdxRateLimitModal,
-      cancelText: i18n.t('common.modal.cancel'),
+      cancelText: null,
       confirmAction: 'refresh'
     })
   })
@@ -43,13 +43,13 @@ describe('globalModalSlice', () => {
       title: '',
       message: '',
       variant: 'alert',
-      confirmText: i18n.t('common.modal.confirm'),
-      cancelText: i18n.t('common.modal.cancel'),
+      confirmText: null,
+      cancelText: null,
       confirmAction: 'close'
     })
   })
 
-  it('uses the current locale for default modal button labels', async () => {
+  it('keeps default modal button labels out of reducer state', async () => {
     await i18n.changeLanguage('en')
 
     const state = globalModalSlice.reducer(undefined, openGlobalModal({
@@ -58,7 +58,7 @@ describe('globalModalSlice', () => {
       variant: 'alert'
     }))
 
-    expect(state.confirmText).toBe(i18n.t('common.modal.confirm'))
-    expect(state.cancelText).toBe(i18n.t('common.modal.cancel'))
+    expect(state.confirmText).toBeNull()
+    expect(state.cancelText).toBeNull()
   })
 })

--- a/app/modules/slices/globalModalSlice.test.ts
+++ b/app/modules/slices/globalModalSlice.test.ts
@@ -8,10 +8,11 @@ import globalModalSlice, {
   closeGlobalModal,
   openGlobalModal
 } from './globalModalSlice'
+import { DEFAULT_APP_LOCALE } from '../consts/i18n'
 
 describe('globalModalSlice', () => {
   afterEach(async () => {
-    await i18n.changeLanguage('zh-TW')
+    await i18n.changeLanguage(DEFAULT_APP_LOCALE)
   })
 
   it('stores modal content and confirm behavior when opened', () => {

--- a/app/modules/slices/globalModalSlice.test.ts
+++ b/app/modules/slices/globalModalSlice.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
-  tdxRateLimitModal,
-  tdxSystemErrorModal
+  getTdxRateLimitModal,
+  getTdxSystemErrorModal
 } from '../apis/errors/busError'
+import i18n from '../i18n'
 import globalModalSlice, {
   closeGlobalModal,
   openGlobalModal
@@ -10,6 +11,7 @@ import globalModalSlice, {
 
 describe('globalModalSlice', () => {
   it('stores modal content and confirm behavior when opened', () => {
+    const tdxRateLimitModal = getTdxRateLimitModal()
     const state = globalModalSlice.reducer(
       undefined,
       openGlobalModal(tdxRateLimitModal)
@@ -18,12 +20,13 @@ describe('globalModalSlice', () => {
     expect(state).toMatchObject({
       opened: true,
       ...tdxRateLimitModal,
-      cancelText: '取消',
+      cancelText: i18n.t('common.modal.cancel'),
       confirmAction: 'refresh'
     })
   })
 
   it('resets modal state when closed', () => {
+    const tdxSystemErrorModal = getTdxSystemErrorModal()
     const openedState = globalModalSlice.reducer(
       undefined,
       openGlobalModal(tdxSystemErrorModal)
@@ -36,8 +39,8 @@ describe('globalModalSlice', () => {
       title: '',
       message: '',
       variant: 'alert',
-      confirmText: '確定',
-      cancelText: '取消',
+      confirmText: i18n.t('common.modal.confirm'),
+      cancelText: i18n.t('common.modal.cancel'),
       confirmAction: 'close'
     })
   })

--- a/app/modules/slices/globalModalSlice.ts
+++ b/app/modules/slices/globalModalSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
-import i18n from '../i18n'
 import type { RootState } from '../store'
 
 type GlobalModalVariant = 'alert' | 'confirm'
@@ -10,27 +9,21 @@ interface GlobalModalState {
   title: string
   message: string
   variant: GlobalModalVariant
-  confirmText: string
-  cancelText: string
+  confirmText: string | null
+  cancelText: string | null
   confirmAction: GlobalModalConfirmAction
 }
 
 export type OpenGlobalModalPayload = Pick<GlobalModalState, 'title' | 'message' | 'variant'> &
   Partial<Pick<GlobalModalState, 'confirmText' | 'cancelText' | 'confirmAction'>>
 
-function getDefaultModalTexts() {
-  return {
-    confirmText: i18n.t('common.modal.confirm'),
-    cancelText: i18n.t('common.modal.cancel')
-  }
-}
-
 const initialState: GlobalModalState = {
   opened: false,
   title: '',
   message: '',
   variant: 'alert',
-  ...getDefaultModalTexts(),
+  confirmText: null,
+  cancelText: null,
   confirmAction: 'close'
 }
 
@@ -42,23 +35,21 @@ const globalModalSlice = createSlice({
       state,
       action: PayloadAction<OpenGlobalModalPayload>
     ) => {
-      const defaultTexts = getDefaultModalTexts()
       state.opened = true
       state.title = action.payload.title
       state.message = action.payload.message
       state.variant = action.payload.variant
-      state.confirmText = action.payload.confirmText ?? defaultTexts.confirmText
-      state.cancelText = action.payload.cancelText ?? defaultTexts.cancelText
+      state.confirmText = action.payload.confirmText ?? null
+      state.cancelText = action.payload.cancelText ?? null
       state.confirmAction = action.payload.confirmAction ?? initialState.confirmAction
     },
     closeGlobalModal: (state) => {
-      const defaultTexts = getDefaultModalTexts()
       state.opened = false
       state.title = initialState.title
       state.message = initialState.message
       state.variant = initialState.variant
-      state.confirmText = defaultTexts.confirmText
-      state.cancelText = defaultTexts.cancelText
+      state.confirmText = initialState.confirmText
+      state.cancelText = initialState.cancelText
       state.confirmAction = initialState.confirmAction
     }
   }

--- a/app/modules/slices/globalModalSlice.ts
+++ b/app/modules/slices/globalModalSlice.ts
@@ -18,13 +18,19 @@ interface GlobalModalState {
 export type OpenGlobalModalPayload = Pick<GlobalModalState, 'title' | 'message' | 'variant'> &
   Partial<Pick<GlobalModalState, 'confirmText' | 'cancelText' | 'confirmAction'>>
 
+function getDefaultModalTexts() {
+  return {
+    confirmText: i18n.t('common.modal.confirm'),
+    cancelText: i18n.t('common.modal.cancel')
+  }
+}
+
 const initialState: GlobalModalState = {
   opened: false,
   title: '',
   message: '',
   variant: 'alert',
-  confirmText: i18n.t('common.modal.confirm'),
-  cancelText: i18n.t('common.modal.cancel'),
+  ...getDefaultModalTexts(),
   confirmAction: 'close'
 }
 
@@ -36,21 +42,23 @@ const globalModalSlice = createSlice({
       state,
       action: PayloadAction<OpenGlobalModalPayload>
     ) => {
+      const defaultTexts = getDefaultModalTexts()
       state.opened = true
       state.title = action.payload.title
       state.message = action.payload.message
       state.variant = action.payload.variant
-      state.confirmText = action.payload.confirmText ?? initialState.confirmText
-      state.cancelText = action.payload.cancelText ?? initialState.cancelText
+      state.confirmText = action.payload.confirmText ?? defaultTexts.confirmText
+      state.cancelText = action.payload.cancelText ?? defaultTexts.cancelText
       state.confirmAction = action.payload.confirmAction ?? initialState.confirmAction
     },
     closeGlobalModal: (state) => {
+      const defaultTexts = getDefaultModalTexts()
       state.opened = false
       state.title = initialState.title
       state.message = initialState.message
       state.variant = initialState.variant
-      state.confirmText = initialState.confirmText
-      state.cancelText = initialState.cancelText
+      state.confirmText = defaultTexts.confirmText
+      state.cancelText = defaultTexts.cancelText
       state.confirmAction = initialState.confirmAction
     }
   }

--- a/app/modules/slices/globalModalSlice.ts
+++ b/app/modules/slices/globalModalSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import i18n from '../i18n'
 import type { RootState } from '../store'
 
 type GlobalModalVariant = 'alert' | 'confirm'
@@ -22,8 +23,8 @@ const initialState: GlobalModalState = {
   title: '',
   message: '',
   variant: 'alert',
-  confirmText: '確定',
-  cancelText: '取消',
+  confirmText: i18n.t('common.modal.confirm'),
+  cancelText: i18n.t('common.modal.cancel'),
   confirmAction: 'close'
 }
 

--- a/app/modules/types/RequireAtLeastOne.ts
+++ b/app/modules/types/RequireAtLeastOne.ts
@@ -1,0 +1,3 @@
+export type RequireAtLeastOne<T> = {
+  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Omit<T, K>>
+}[keyof T]

--- a/app/modules/utils/createMapMarkerElement.ts
+++ b/app/modules/utils/createMapMarkerElement.ts
@@ -1,6 +1,7 @@
 type MapMarkerType = 'stop' | 'vehicle' | 'user'
 
 interface CreateMapMarkerElementOptions {
+  ariaLabel?: string
   backgroundColor?: string
   boxShadow?: string
   datasetLabel?: string
@@ -42,6 +43,7 @@ const markerStyleMap: Record<MapMarkerType, Partial<CSSStyleDeclaration>> = {
 }
 
 export const createMapMarkerElement = ({
+  ariaLabel,
   backgroundColor,
   boxShadow,
   datasetLabel,
@@ -67,6 +69,10 @@ export const createMapMarkerElement = ({
 
   if (datasetLabel) {
     element.dataset.label = datasetLabel
+  }
+
+  if (ariaLabel) {
+    element.setAttribute('aria-label', ariaLabel)
   }
 
   if (textContent) {

--- a/app/modules/utils/getAreaLabel.ts
+++ b/app/modules/utils/getAreaLabel.ts
@@ -1,0 +1,7 @@
+import type { TFunction } from 'i18next'
+import { areaTranslationKeyMap } from '../consts/area'
+import type { AreaType } from '../enums/AreaType'
+
+export function getAreaLabel(t: TFunction, area: AreaType) {
+  return t(areaTranslationKeyMap[area])
+}

--- a/app/modules/utils/getCityLabel.ts
+++ b/app/modules/utils/getCityLabel.ts
@@ -1,0 +1,7 @@
+import type { TFunction } from 'i18next'
+import { cityTranslationKeyMap } from '../consts/city'
+import type { CityNameType } from '../enums/CityNameType'
+
+export function getCityLabel(t: TFunction, city: CityNameType) {
+  return t(cityTranslationKeyMap[city])
+}

--- a/app/modules/utils/getDirectionLabel.ts
+++ b/app/modules/utils/getDirectionLabel.ts
@@ -1,0 +1,7 @@
+import type { TFunction } from 'i18next'
+import { directionTranslationKeyMap } from '../consts/direction'
+import { DirectionType } from '../enums/DirectionType'
+
+export function getDirectionLabel(t: TFunction, direction: DirectionType) {
+  return t(directionTranslationKeyMap[direction] ?? directionTranslationKeyMap[DirectionType.UNKNOWN])
+}

--- a/app/modules/utils/getRouteRealtimeBusStatuses.test.ts
+++ b/app/modules/utils/getRouteRealtimeBusStatuses.test.ts
@@ -4,7 +4,13 @@ import { CityNameType } from '../enums/CityNameType'
 import { DirectionType } from '../enums/DirectionType'
 import { DutyStatusType } from '../enums/DutyStatusType'
 import { StopStatusType } from '../enums/StopStatusType'
+import i18n from '../i18n'
 import { getRouteRealtimeBusStatuses } from './getRouteRealtimeBusStatuses'
+
+const fourMinutesAwayLabel = i18n.t('routePage.realtime.minutesAway', { count: 4 })
+const twoMinutesAwayLabel = i18n.t('routePage.realtime.minutesAway', { count: 2 })
+const inServiceLabel = i18n.t('routePage.realtime.inService')
+const comingSoonLabel = i18n.t('routePage.realtime.comingSoon')
 
 describe('getRouteRealtimeBusStatuses', () => {
   it('matches a realtime bus with its estimated arrival by plate number and formats minutes', () => {
@@ -52,9 +58,9 @@ describe('getRouteRealtimeBusStatuses', () => {
       City: CityNameType.TAIPEI
     }]
 
-    expect(getRouteRealtimeBusStatuses(realtimeBuses, estimatedArrivals)).toEqual([
+    expect(getRouteRealtimeBusStatuses(i18n.t, realtimeBuses, estimatedArrivals)).toEqual([
       expect.objectContaining({
-        estimateLabel: '4 分後到站',
+        estimateLabel: fourMinutesAwayLabel,
         estimateMinutes: 4,
         plateNumb: 'ABC-123',
         stopName: '市政府'
@@ -107,9 +113,9 @@ describe('getRouteRealtimeBusStatuses', () => {
       City: CityNameType.TAIPEI
     }]
 
-    expect(getRouteRealtimeBusStatuses(realtimeBuses, estimatedArrivals)).toEqual([
+    expect(getRouteRealtimeBusStatuses(i18n.t, realtimeBuses, estimatedArrivals)).toEqual([
       expect.objectContaining({
-        estimateLabel: '行駛中',
+        estimateLabel: inServiceLabel,
         estimateMinutes: null,
         stopName: '捷運昆陽站'
       })
@@ -161,9 +167,9 @@ describe('getRouteRealtimeBusStatuses', () => {
       City: CityNameType.TAIPEI
     }]
 
-    expect(getRouteRealtimeBusStatuses(realtimeBuses, estimatedArrivals)).toEqual([
+    expect(getRouteRealtimeBusStatuses(i18n.t, realtimeBuses, estimatedArrivals)).toEqual([
       expect.objectContaining({
-        estimateLabel: '4 分後到站',
+        estimateLabel: fourMinutesAwayLabel,
         estimateMinutes: 4,
         stopName: '市政府'
       })
@@ -215,9 +221,9 @@ describe('getRouteRealtimeBusStatuses', () => {
       City: CityNameType.TAIPEI
     }]
 
-    expect(getRouteRealtimeBusStatuses(realtimeBuses, estimatedArrivals)).toEqual([
+    expect(getRouteRealtimeBusStatuses(i18n.t, realtimeBuses, estimatedArrivals)).toEqual([
       expect.objectContaining({
-        estimateLabel: '2 分後到站',
+        estimateLabel: twoMinutesAwayLabel,
         estimateMinutes: 2,
         plateNumb: 'eal-1095'
       })
@@ -290,9 +296,9 @@ describe('getRouteRealtimeBusStatuses', () => {
       }
     ]
 
-    expect(getRouteRealtimeBusStatuses(realtimeBuses, estimatedArrivals)).toEqual([
+    expect(getRouteRealtimeBusStatuses(i18n.t, realtimeBuses, estimatedArrivals)).toEqual([
       expect.objectContaining({
-        estimateLabel: '即將進站',
+        estimateLabel: comingSoonLabel,
         estimateMinutes: 1,
         plateNumb: 'KKA-0151'
       })
@@ -365,9 +371,9 @@ describe('getRouteRealtimeBusStatuses', () => {
       }
     ]
 
-    expect(getRouteRealtimeBusStatuses(realtimeBuses, estimatedArrivals)).toEqual([
+    expect(getRouteRealtimeBusStatuses(i18n.t, realtimeBuses, estimatedArrivals)).toEqual([
       expect.objectContaining({
-        estimateLabel: '2 分後到站',
+        estimateLabel: twoMinutesAwayLabel,
         estimateMinutes: 2,
         plateNumb: 'KKA-0151'
       })

--- a/app/modules/utils/getRouteRealtimeBusStatuses.test.ts
+++ b/app/modules/utils/getRouteRealtimeBusStatuses.test.ts
@@ -6,11 +6,13 @@ import { DutyStatusType } from '../enums/DutyStatusType'
 import { StopStatusType } from '../enums/StopStatusType'
 import i18n from '../i18n'
 import { getRouteRealtimeBusStatuses } from './getRouteRealtimeBusStatuses'
+import { DEFAULT_APP_LOCALE } from '../consts/i18n'
 
-const fourMinutesAwayLabel = i18n.t('routePage.realtime.minutesAway', { count: 4 })
-const twoMinutesAwayLabel = i18n.t('routePage.realtime.minutesAway', { count: 2 })
-const inServiceLabel = i18n.t('routePage.realtime.inService')
-const comingSoonLabel = i18n.t('routePage.realtime.comingSoon')
+const t = i18n.getFixedT(DEFAULT_APP_LOCALE)
+const fourMinutesAwayLabel = t('routePage.realtime.minutesAway', { count: 4 })
+const twoMinutesAwayLabel = t('routePage.realtime.minutesAway', { count: 2 })
+const inServiceLabel = t('routePage.realtime.inService')
+const comingSoonLabel = t('routePage.realtime.comingSoon')
 
 describe('getRouteRealtimeBusStatuses', () => {
   it('matches a realtime bus with its estimated arrival by plate number and formats minutes', () => {

--- a/app/modules/utils/getRouteRealtimeBusStatuses.ts
+++ b/app/modules/utils/getRouteRealtimeBusStatuses.ts
@@ -106,13 +106,7 @@ export function getRouteRealtimeBusStatuses(
           ? stopMatchedArrival
           : nextEstimatedArrival ?? stopMatchedArrival)
       const estimateLabel = matchedArrival
-        ? formatEstimatedArrivalLabel(
-            t,
-            matchedArrival.EstimateTime,
-            matchedArrival.EstimateTime == null
-              ? matchedArrival.StopStatus
-              : matchedArrival.StopStatus
-          )
+        ? formatEstimatedArrivalLabel(t, matchedArrival.EstimateTime, matchedArrival.StopStatus)
         : getRealtimeFallbackLabel(t, StopStatusType.UNKNOWN)
       const shouldUseRealtimeFallbackLabel =
         matchedArrival != null &&

--- a/app/modules/utils/getRouteRealtimeBusStatuses.ts
+++ b/app/modules/utils/getRouteRealtimeBusStatuses.ts
@@ -1,4 +1,5 @@
-import { stopStatusMapLabel } from '../consts/stopStatus'
+import type { TFunction } from 'i18next'
+import { stopStatusTranslationKeyMap } from '../consts/stopStatus'
 import { StopStatusType } from '../enums/StopStatusType'
 import type { EstimatedArrival } from '../interfaces/EstimatedArrival'
 import type { RealtimeNearStop } from '../interfaces/RealtimeNearStop'
@@ -8,12 +9,16 @@ function normalizePlateNumb(plateNumb: string | null | undefined) {
   return plateNumb?.trim().toUpperCase() ?? null
 }
 
-function getRealtimeFallbackLabel(stopStatus: StopStatusType) {
+function getStopStatusLabel(t: TFunction, stopStatus: StopStatusType) {
+  return t(stopStatusTranslationKeyMap[stopStatus])
+}
+
+function getRealtimeFallbackLabel(t: TFunction, stopStatus: StopStatusType) {
   if ([StopStatusType.NOT_YET_DEPARTED, StopStatusType.UNKNOWN].includes(stopStatus)) {
-    return '行駛中'
+    return t('routePage.realtime.inService')
   }
 
-  return stopStatusMapLabel[stopStatus]
+  return getStopStatusLabel(t, stopStatus)
 }
 
 function isStrongArrivalMatch(estimatedArrival: EstimatedArrival | undefined) {
@@ -32,16 +37,18 @@ function isStrongArrivalMatch(estimatedArrival: EstimatedArrival | undefined) {
   ].includes(estimatedArrival.StopStatus)
 }
 
-export function formatEstimatedArrivalLabel(estimateTime: number | null, stopStatus: StopStatusType) {
+export function formatEstimatedArrivalLabel(t: TFunction, estimateTime: number | null, stopStatus: StopStatusType) {
   if (estimateTime != null) {
-    if (estimateTime <= 60) return '即將進站'
-    return `${Math.ceil(estimateTime / 60)} 分後到站`
+    if (estimateTime <= 60) return t('routePage.realtime.comingSoon')
+    const minutes = Math.ceil(estimateTime / 60)
+    return t('routePage.realtime.minutesAway', { count: minutes })
   }
-  if (stopStatus === StopStatusType.NORMAL) return '暫無預估'
-  return stopStatusMapLabel[stopStatus]
+  if (stopStatus === StopStatusType.NORMAL) return t('routePage.realtime.noEstimate')
+  return getStopStatusLabel(t, stopStatus)
 }
 
 export function getRouteRealtimeBusStatuses(
+  t: TFunction,
   realtimeBuses: RealtimeNearStop[],
   estimatedArrivals: EstimatedArrival[]
 ): RouteRealtimeBusStatus[] {
@@ -100,12 +107,13 @@ export function getRouteRealtimeBusStatuses(
           : nextEstimatedArrival ?? stopMatchedArrival)
       const estimateLabel = matchedArrival
         ? formatEstimatedArrivalLabel(
+            t,
             matchedArrival.EstimateTime,
             matchedArrival.EstimateTime == null
               ? matchedArrival.StopStatus
               : matchedArrival.StopStatus
           )
-        : getRealtimeFallbackLabel(StopStatusType.UNKNOWN)
+        : getRealtimeFallbackLabel(t, StopStatusType.UNKNOWN)
       const shouldUseRealtimeFallbackLabel =
         matchedArrival != null &&
         matchedArrival.EstimateTime == null &&
@@ -114,7 +122,7 @@ export function getRouteRealtimeBusStatuses(
       return {
         direction: realtimeBus.Direction,
         estimateLabel: shouldUseRealtimeFallbackLabel
-          ? getRealtimeFallbackLabel(matchedArrival.StopStatus)
+          ? getRealtimeFallbackLabel(t, matchedArrival.StopStatus)
           : estimateLabel,
         estimateMinutes: matchedArrival?.EstimateTime != null
           ? Math.ceil(matchedArrival.EstimateTime / 60)

--- a/app/modules/utils/map/addMapMarkerActivationListeners.ts
+++ b/app/modules/utils/map/addMapMarkerActivationListeners.ts
@@ -1,5 +1,9 @@
-function isActivationKey(event: KeyboardEvent) {
-  return event.key === 'Enter' || event.key === ' '
+function isEnterKey(event: KeyboardEvent) {
+  return event.key === 'Enter'
+}
+
+function isSpaceKey(event: KeyboardEvent) {
+  return event.key === ' '
 }
 
 export function addMapMarkerActivationListeners(
@@ -7,10 +11,26 @@ export function addMapMarkerActivationListeners(
   onActivate: (event: MouseEvent | KeyboardEvent) => void
 ) {
   const handleKeyDown = (event: KeyboardEvent) => {
-    if (!isActivationKey(event)) return
+    if (event.repeat) return
+
+    if (isEnterKey(event)) {
+      onActivate(event)
+      return
+    }
+
+    if (isSpaceKey(event)) {
+      // Match native button behavior by preventing page scroll on keydown
+      // and triggering activation on keyup instead.
+      event.preventDefault()
+    }
+  }
+
+  const handleKeyUp = (event: KeyboardEvent) => {
+    if (!isSpaceKey(event)) return
     onActivate(event)
   }
 
   element.addEventListener('click', onActivate)
   element.addEventListener('keydown', handleKeyDown)
+  element.addEventListener('keyup', handleKeyUp)
 }

--- a/app/modules/utils/map/addMapMarkerActivationListeners.ts
+++ b/app/modules/utils/map/addMapMarkerActivationListeners.ts
@@ -3,7 +3,7 @@ function isEnterKey(event: KeyboardEvent) {
 }
 
 function isSpaceKey(event: KeyboardEvent) {
-  return event.key === ' '
+  return event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space'
 }
 
 export function addMapMarkerActivationListeners(
@@ -33,4 +33,10 @@ export function addMapMarkerActivationListeners(
   element.addEventListener('click', onActivate)
   element.addEventListener('keydown', handleKeyDown)
   element.addEventListener('keyup', handleKeyUp)
+
+  return () => {
+    element.removeEventListener('click', onActivate)
+    element.removeEventListener('keydown', handleKeyDown)
+    element.removeEventListener('keyup', handleKeyUp)
+  }
 }

--- a/app/modules/utils/map/addMapMarkerActivationListeners.ts
+++ b/app/modules/utils/map/addMapMarkerActivationListeners.ts
@@ -1,0 +1,16 @@
+function isActivationKey(event: KeyboardEvent) {
+  return event.key === 'Enter' || event.key === ' '
+}
+
+export function addMapMarkerActivationListeners(
+  element: HTMLElement,
+  onActivate: (event: MouseEvent | KeyboardEvent) => void
+) {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!isActivationKey(event)) return
+    onActivate(event)
+  }
+
+  element.addEventListener('click', onActivate)
+  element.addEventListener('keydown', handleKeyDown)
+}

--- a/app/modules/utils/map/createMapMarkerElement.ts
+++ b/app/modules/utils/map/createMapMarkerElement.ts
@@ -7,6 +7,7 @@ interface CreateMapMarkerElementOptions {
   datasetLabel?: string
   fontSize?: string
   fontWeight?: string
+  interactive?: boolean
   textContent?: string
   title?: string
   type: MapMarkerType
@@ -49,6 +50,7 @@ export const createMapMarkerElement = ({
   datasetLabel,
   fontSize,
   fontWeight,
+  interactive = false,
   textContent,
   title,
   type
@@ -62,7 +64,7 @@ export const createMapMarkerElement = ({
     justifyContent: 'center',
     backgroundColor: backgroundColor ?? markerStyleMap[type].backgroundColor,
     boxShadow,
-    cursor: 'pointer',
+    cursor: interactive ? 'pointer' : 'default',
     fontSize: fontSize ?? markerStyleMap[type].fontSize,
     fontWeight: fontWeight ?? markerStyleMap[type].fontWeight
   } satisfies Partial<CSSStyleDeclaration>)
@@ -73,6 +75,13 @@ export const createMapMarkerElement = ({
 
   if (ariaLabel) {
     element.setAttribute('aria-label', ariaLabel)
+  }
+
+  if (interactive) {
+    element.setAttribute('role', 'button')
+    element.tabIndex = 0
+  } else if (ariaLabel) {
+    element.setAttribute('role', 'img')
   }
 
   if (textContent) {

--- a/app/pages/AppLayout.test.tsx
+++ b/app/pages/AppLayout.test.tsx
@@ -49,7 +49,9 @@ vi.mock('@mantine/hooks', async () => {
 })
 
 vi.mock('~/components/AppNavLink', () => ({
-  AppNavLink: ({ label }: { label: string }) => <div>{label}</div>
+  AppNavLink: ({ label, ariaLabel }: { label?: string, ariaLabel?: string }) => (
+    <div aria-label={ariaLabel ?? label}>{label}</div>
+  )
 }))
 
 vi.mock('~/modules/hooks/useWatchGeo', () => ({
@@ -114,7 +116,7 @@ describe('AppLayout', () => {
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('renders the settings navigation entry in the desktop header', () => {
+  it('renders an accessible settings navigation entry in the desktop header', () => {
     mockUseSelector.mockImplementation((selector: (state: unknown) => unknown) => selector({
       geolocation: {
         coords: null
@@ -128,7 +130,7 @@ describe('AppLayout', () => {
 
     expect(mockFetchCityGeoJSON).toHaveBeenCalledOnce()
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'cityGeo/fetchCityGeoJSON' })
-    expect(screen.getAllByText(i18n.t('layout.nav.settings')).length).toBeGreaterThan(0)
+    expect(screen.getByLabelText(i18n.t('layout.nav.settings'))).toBeInTheDocument()
   })
 
   it('uses the settings action icon outside the settings page on mobile', () => {

--- a/app/pages/AppLayout.tsx
+++ b/app/pages/AppLayout.tsx
@@ -15,7 +15,6 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Outlet, useLocation, useNavigate } from 'react-router'
 import { AppNavLink } from '~/components/AppNavLink'
-import i18n from '~/modules/i18n'
 import {
   APP_FLOATING_ACTION_OFFSET,
   APP_FOOTER_HEIGHT,
@@ -24,13 +23,6 @@ import {
 import { useWatchGeo } from '~/modules/hooks/useWatchGeo'
 import { fetchCityGeoJSON } from '~/modules/slices/cityGeoSlice'
 import type { AppDispatch, RootState } from '~/modules/store'
-
-export function meta() {
-  return [
-    { title: i18n.t('app.name') },
-    { name: 'description', content: i18n.t('app.description') }
-  ]
-}
 
 export default function AppLayout () {
   const dispatch = useDispatch<AppDispatch>()

--- a/app/pages/AppLayout.tsx
+++ b/app/pages/AppLayout.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Outlet, useLocation, useNavigate } from 'react-router'
 import { AppNavLink } from '~/components/AppNavLink'
+import i18n from '~/modules/i18n'
 import {
   APP_FLOATING_ACTION_OFFSET,
   APP_FOOTER_HEIGHT,
@@ -26,8 +27,8 @@ import type { AppDispatch, RootState } from '~/modules/store'
 
 export function meta() {
   return [
-    { title: 'Finding the Bus' },
-    { name: 'description', content: 'Go find the bus you\'ve been waiting for your whole life. (Just kidding.)' }
+    { title: i18n.t('app.name') },
+    { name: 'description', content: i18n.t('app.description') }
   ]
 }
 

--- a/app/pages/AppLayout.tsx
+++ b/app/pages/AppLayout.tsx
@@ -97,6 +97,7 @@ export default function AppLayout () {
           </Flex>
           <Flex ml="auto">
             <AppNavLink
+              ariaLabel={settingNav.name}
               icon={settingNav.icon}
               iconActive={settingNav.iconActive}
               to={settingNav.path}

--- a/app/pages/AppLayout.tsx
+++ b/app/pages/AppLayout.tsx
@@ -97,7 +97,8 @@ export default function AppLayout () {
           </Flex>
           <Flex ml="auto">
             <AppNavLink
-              label={settingNav.name}
+              icon={settingNav.icon}
+              iconActive={settingNav.iconActive}
               to={settingNav.path}
             />
           </Flex>

--- a/app/pages/Route.test.tsx
+++ b/app/pages/Route.test.tsx
@@ -3,13 +3,17 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import i18n from '~/modules/i18n'
-import { routeRealtimeMessages } from '~/modules/consts/routeRealtimeMessages'
+import { getRouteRealtimeMessages } from '~/modules/consts/routeRealtimeMessages'
 import { CityNameType } from '~/modules/enums/CityNameType'
 import { DirectionType } from '~/modules/enums/DirectionType'
 import { StopStatusType } from '~/modules/enums/StopStatusType'
 import type { FavoriteRouteStop } from '~/modules/interfaces/FavoriteRouteStop'
 import { renderRoute } from '~/test/render'
 import Route from './Route'
+
+const fourMinutesAwayLabel = i18n.t('routePage.realtime.minutesAway', { count: 4 })
+const noEstimateLabel = i18n.t('routePage.realtime.noEstimate')
+const routeRealtimeMessages = getRouteRealtimeMessages(i18n.t)
 
 const {
   mockToggleFavoriteRouteStop,
@@ -336,7 +340,7 @@ describe('Route', () => {
 
     await waitFor(() => {
       expect(screen.getByText('市政府').closest('[data-highlighted="true"]')).toBeInTheDocument()
-      expect(screen.getByText('4 分後到站')).toBeInTheDocument()
+      expect(screen.getByText(fourMinutesAwayLabel)).toBeInTheDocument()
     })
   })
 
@@ -441,7 +445,7 @@ describe('Route', () => {
     fireEvent.click(screen.getByRole('tab', { name: '返程' }))
 
     await waitFor(() => {
-      expect(screen.getByText('4 分後到站')).toBeInTheDocument()
+      expect(screen.getByText(fourMinutesAwayLabel)).toBeInTheDocument()
       expect(screen.queryByText(routeRealtimeMessages.noRealtimeData.description)).not.toBeInTheDocument()
     })
   })
@@ -472,8 +476,8 @@ describe('Route', () => {
     fireEvent.click(screen.getByRole('tab', { name: '返程' }))
 
     await waitFor(() => {
-      expect(screen.getByText('4 分後到站')).toBeInTheDocument()
-      expect(screen.queryByText('暫無預估')).not.toBeInTheDocument()
+      expect(screen.getByText(fourMinutesAwayLabel)).toBeInTheDocument()
+      expect(screen.queryByText(noEstimateLabel)).not.toBeInTheDocument()
     })
   })
 

--- a/app/pages/Route.test.tsx
+++ b/app/pages/Route.test.tsx
@@ -10,10 +10,12 @@ import { StopStatusType } from '~/modules/enums/StopStatusType'
 import type { FavoriteRouteStop } from '~/modules/interfaces/FavoriteRouteStop'
 import { renderRoute } from '~/test/render'
 import Route from './Route'
+import { DEFAULT_APP_LOCALE } from '~/modules/consts/i18n'
 
-const fourMinutesAwayLabel = i18n.t('routePage.realtime.minutesAway', { count: 4 })
-const noEstimateLabel = i18n.t('routePage.realtime.noEstimate')
-const routeRealtimeMessages = getRouteRealtimeMessages(i18n.t)
+const t = i18n.getFixedT(DEFAULT_APP_LOCALE)
+const fourMinutesAwayLabel = t('routePage.realtime.minutesAway', { count: 4 })
+const noEstimateLabel = t('routePage.realtime.noEstimate')
+const routeRealtimeMessages = getRouteRealtimeMessages(t)
 
 const {
   mockToggleFavoriteRouteStop,

--- a/app/pages/Routes.tsx
+++ b/app/pages/Routes.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex, Group, ScrollArea, Skeleton, Stack, Title } from '@mantine/core'
+import { Card, Flex, ScrollArea, Skeleton, Stack, Title } from '@mantine/core'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -87,13 +87,13 @@ export default function Routes() {
           <Stack gap={4}>
             <Title order={3}>{t('pages.routes.title')}</Title>
           </Stack>
-          <Group>
+          <Flex gap="sm" align="stretch">
             <AreaSelect value={area} onChange={(nextArea) => dispatch(setSelectedArea(nextArea))} />
             <SearchInput
               value={keyword}
               onChange={(nextKeyword) => dispatch(setKeyword(nextKeyword))}
             />
-          </Group>
+          </Flex>
           {message && <BaseAlert {...message} />}
           <ScrollArea style={{ flex: 1, minHeight: 0 }}>
             <Stack gap="sm">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -72,10 +72,12 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   let stack: string | undefined
 
   if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? '404' : 'Error'
+    message = error.status === 404
+      ? i18n.t('errorBoundary.notFound.title')
+      : i18n.t('errorBoundary.default.title')
     details =
       error.status === 404
-        ? 'The requested page could not be found.'
+        ? i18n.t('errorBoundary.notFound.description')
         : error.statusText || details
   } else if (import.meta.env.DEV && error && error instanceof Error) {
     details = error.message

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -33,6 +33,15 @@ export const links: Route.LinksFunction = () => [
   }
 ]
 
+export function meta() {
+  const t = i18n.getFixedT(DEFAULT_APP_LOCALE)
+
+  return [
+    { title: t('app.name') },
+    { name: 'description', content: t('app.description') }
+  ]
+}
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang={i18n.resolvedLanguage ?? i18n.language ?? DEFAULT_APP_LOCALE}>


### PR DESCRIPTION
## Related

- Part of #2

## Summary

This PR introduces phase 3 of the app's i18n rollout.

## What Changed

- expand `zh-TW` and `en` locale resources for shared UI, route realtime, bus-service modal, and error boundary copy
- add shared translation helpers for area, city, and direction labels
- replace hard-coded static copy in shared components such as:
  - `SearchInput`
  - `AreaSelect`
  - `FavoriteRouteStopCard`
  - `RouteInfoCard`
  - `NearbyStopRoutes`
  - `BaseModal`
- localize map marker accessibility labels and related popup text
- localize route realtime ETA / status messaging and alert content
- localize app metadata and route error boundary copy
- update `AppNavLink` so icon-only nav entries can provide explicit `aria-label`s
- convert `cityGeoSlice` internal error messages to English developer-facing text
- update related tests

## Validation

- `pnpm run lint`
- `pnpm run typecheck`

## Scope Notes

Included in this phase:
- static UI copy migration
- translation-backed shared labels and messages
- accessibility-label localization
- route realtime copy localization

Not included yet:
- locale-aware rendering for TDX-backed route, subroute, stop, departure, and destination names

## Reviewer Notes

The main review focus for this PR is whether static copy migration is complete and whether the remaining API-backed localization work is still clearly separated for phase 4.