### PR TITLE
fix(route): stabilize route stop realtime badge layout and selection

### DIFF
--- a/app/components/routes/RouteRealtimeBadge.tsx
+++ b/app/components/routes/RouteRealtimeBadge.tsx
@@ -6,9 +6,11 @@ interface PropType {
   isSelected: boolean
   onClick: (event: MouseEvent<HTMLButtonElement>) => void
   plateNumb: string
+  buttonRef?: (node: HTMLButtonElement | null) => void
 }
 
 export function RouteRealtimeBadge({
+  buttonRef,
   isSelected,
   onClick,
   plateNumb
@@ -20,6 +22,7 @@ export function RouteRealtimeBadge({
       }}
     >
       <Badge
+        ref={buttonRef}
         component="button"
         type="button"
         aria-pressed={isSelected}

--- a/app/components/routes/RouteRealtimeGap.tsx
+++ b/app/components/routes/RouteRealtimeGap.tsx
@@ -2,32 +2,33 @@ import { Box, Group } from '@mantine/core'
 import type { RouteRealtimeBusStatus } from '~/modules/interfaces/RouteRealtimeBusStatus'
 import { RouteRealtimeBadge } from './RouteRealtimeBadge'
 
-const ROUTE_STOP_FAVORITE_ACTION_OFFSET = 'calc(var(--ai-size-md) + var(--mantine-spacing-xs))'
-
 interface PropType {
   realtimeBuses: RouteRealtimeBusStatus[]
   onSelectVehicle: (vehicleId: string) => void
+  setVehicleBadgeRef?: (vehicleId: string, node: HTMLButtonElement | null) => void
   selectedVehicleId?: string | null
 }
 
 export function RouteRealtimeGap({
   realtimeBuses,
   onSelectVehicle,
+  setVehicleBadgeRef,
   selectedVehicleId = null
 }: PropType) {
   return (
     <Box mih={28} pr="sm">
-      <Group wrap="nowrap" justify="flex-end" align="center">
+      <Group wrap="nowrap" justify="space-between" align="flex-start">
+        <Box style={{ flex: 1, minWidth: 0 }} />
         <Group
           gap="xs"
           wrap="wrap"
-          justify="flex-end"
-          pr={ROUTE_STOP_FAVORITE_ACTION_OFFSET}
-          style={{ flex: 1, minHeight: 28 }}
+          justify="flex-start"
+          style={{ flex: '0 0 auto', minHeight: 28, minWidth: 'max-content' }}
         >
           {realtimeBuses.map((bus) => (
             <RouteRealtimeBadge
               key={bus.id}
+              buttonRef={(node) => setVehicleBadgeRef?.(bus.id, node)}
               isSelected={bus.id === selectedVehicleId}
               plateNumb={bus.plateNumb}
               onClick={(event) => {

--- a/app/components/routes/RouteRealtimeGap.tsx
+++ b/app/components/routes/RouteRealtimeGap.tsx
@@ -24,7 +24,7 @@ export function RouteRealtimeGap({
           wrap="wrap"
           justify="flex-start"
           pr="xl"
-          style={{ flex: '0 0 auto', minHeight: 28, minWidth: 'max-content' }}
+          style={{ flex: '0 1 auto', minHeight: 28, minWidth: 0 }}
         >
           {realtimeBuses.map((bus) => (
             <RouteRealtimeBadge

--- a/app/components/routes/RouteRealtimeGap.tsx
+++ b/app/components/routes/RouteRealtimeGap.tsx
@@ -23,6 +23,7 @@ export function RouteRealtimeGap({
           gap="xs"
           wrap="wrap"
           justify="flex-start"
+          pr="xl"
           style={{ flex: '0 0 auto', minHeight: 28, minWidth: 'max-content' }}
         >
           {realtimeBuses.map((bus) => (

--- a/app/components/routes/RouteStopList.tsx
+++ b/app/components/routes/RouteStopList.tsx
@@ -55,6 +55,7 @@ export const RouteStopList = ({
 }: PropType) => {
   const { t } = useTranslation()
   const stopItemRefs = useRef<Map<string, HTMLDivElement | null>>(new Map())
+  const vehicleBadgeRefs = useRef<Map<string, HTMLButtonElement | null>>(new Map())
   const routeRealtimeMessages = getRouteRealtimeMessages(t)
 
   useScrollSelectedItem({
@@ -71,6 +72,13 @@ export const RouteStopList = ({
     verticalAlignment: listScrollBehavior
   })
 
+  useScrollSelectedItem({
+    itemElementRefs: vehicleBadgeRefs,
+    listItems: stops,
+    selectedItemId: selectedVehicleId,
+    verticalAlignment: listScrollBehavior
+  })
+
   const realtimeMessage = (() => {
     if (isLoading) return null
     if (isRealtimeLoading) return routeRealtimeMessages.loading
@@ -81,6 +89,15 @@ export const RouteStopList = ({
     }
     return null
   })()
+
+  const setVehicleBadgeRef = (vehicleId: string, node: HTMLButtonElement | null) => {
+    if (node) {
+      vehicleBadgeRefs.current.set(vehicleId, node)
+      return
+    }
+
+    vehicleBadgeRefs.current.delete(vehicleId)
+  }
 
   return (
     <Stack h="100%" gap="xs" style={{ minHeight: 0 }}>
@@ -189,11 +206,17 @@ export const RouteStopList = ({
                               </Text>
                             )}
                           </Stack>
-                            <Group pr="sm" gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
-                            <Group gap="xs" wrap="wrap" justify="flex-end">
+                          <Stack
+                            gap={6}
+                            align="flex-start"
+                            pr="sm"
+                            style={{ flex: '0 0 auto', minWidth: 'max-content' }}
+                          >
+                            <Group gap="xs" wrap="wrap" justify="flex-start">
                               {stopLevelRealtimeBuses.map((bus) => (
                                 <RouteRealtimeBadge
                                   key={bus.id}
+                                  buttonRef={(node) => setVehicleBadgeRef(bus.id, node)}
                                   isSelected={bus.id === selectedVehicleId}
                                   plateNumb={bus.plateNumb}
                                   onClick={(event) => {
@@ -217,7 +240,7 @@ export const RouteStopList = ({
                             >
                               {stop.isFavorite ? <RiHeart2Fill /> : <RiHeart2Line />}
                             </ActionIcon>
-                          </Group>
+                          </Stack>
                         </Group>
                       </Box>
                     )}
@@ -226,6 +249,7 @@ export const RouteStopList = ({
                       <RouteRealtimeGap
                         realtimeBuses={gapRealtimeBuses}
                         onSelectVehicle={onSelectVehicle}
+                        setVehicleBadgeRef={setVehicleBadgeRef}
                         selectedVehicleId={selectedVehicleId}
                       />
                     )}

--- a/app/components/routes/RouteStopList.tsx
+++ b/app/components/routes/RouteStopList.tsx
@@ -232,7 +232,13 @@ export const RouteStopList = ({
                                   </Text>
                                 )}
                               </Box>
-                              <Group gap="xs" wrap="wrap" justify="flex-end" pr="xl" style={{ flexShrink: 0 }}>
+                              <Group
+                                gap="xs"
+                                wrap="wrap"
+                                justify="flex-end"
+                                pr="xl"
+                                style={{ minWidth: 0, maxWidth: '100%' }}
+                              >
                                 {stopLevelRealtimeBuses.map((bus) => (
                                   <RouteRealtimeBadge
                                     key={bus.id}

--- a/app/components/routes/RouteStopList.tsx
+++ b/app/components/routes/RouteStopList.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, Alert, Box, Group, ScrollArea, Skeleton, Stack, Text, Timeline } from '@mantine/core'
 import { RiHeart2Fill, RiHeart2Line } from '@remixicon/react'
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getRouteRealtimeMessages } from '~/modules/consts/routeRealtimeMessages'
 import { RouteRealtimeInfoState } from '~/modules/enums/RouteRealtimeInfoState'
@@ -57,24 +57,29 @@ export const RouteStopList = ({
   const stopItemRefs = useRef<Map<string, HTMLDivElement | null>>(new Map())
   const vehicleBadgeRefs = useRef<Map<string, HTMLButtonElement | null>>(new Map())
   const routeRealtimeMessages = getRouteRealtimeMessages(t)
+  const stopIdsKey = useMemo(() => stops.map((stop) => stop.id).join('|'), [stops])
+  const vehicleIdsKey = useMemo(
+    () => stops.flatMap((stop) => stop.realtimeBuses.map((bus) => bus.id)).join('|'),
+    [stops]
+  )
 
   useScrollSelectedItem({
     itemElementRefs: stopItemRefs,
-    listItems: stops,
+    listItems: stopIdsKey,
     selectedItemId: highlightedStopId,
     verticalAlignment: 'center'
   })
 
   useScrollSelectedItem({
     itemElementRefs: stopItemRefs,
-    listItems: stops,
+    listItems: stopIdsKey,
     selectedItemId: selectedStopId,
     verticalAlignment: listScrollBehavior
   })
 
   useScrollSelectedItem({
     itemElementRefs: vehicleBadgeRefs,
-    listItems: stops,
+    listItems: vehicleIdsKey,
     selectedItemId: selectedVehicleId,
     verticalAlignment: listScrollBehavior
   })

--- a/app/components/routes/RouteStopList.tsx
+++ b/app/components/routes/RouteStopList.tsx
@@ -181,19 +181,22 @@ export const RouteStopList = ({
                         }}
                         data-highlighted={isHighlighted || undefined}
                         data-selected={isSelected || undefined}
-                        px="xs"
-                        py={4}
+                        pl="xs"
+                        pt={4}
+                        pb="xs"
                         bg={isHighlighted ? 'blue.0' : undefined}
                         style={{ borderRadius: 'var(--mantine-radius-sm)' }}
                       >
-                        <Group justify="space-between" align="flex-start" wrap="nowrap">
-                          <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
+                        <Stack gap={4} pr="sm">
+                          <Group justify="space-between" align="center" wrap="nowrap">
                             <Text
                               component="button"
                               type="button"
+                              lineClamp={1}
                               fw={isHighlighted || isSelected ? 700 : undefined}
                               c={isHighlighted ? 'blue.8' : undefined}
                               style={{
+                                flex: 1,
                                 minWidth: 0,
                                 cursor: 'pointer',
                                 background: 'none',
@@ -205,32 +208,6 @@ export const RouteStopList = ({
                             >
                               {stop.name}
                             </Text>
-                            {stop.estimatedArrivalLabel && (
-                              <Text size="xs" c="dimmed">
-                                {stop.estimatedArrivalLabel}
-                              </Text>
-                            )}
-                          </Stack>
-                          <Stack
-                            gap={6}
-                            align="flex-start"
-                            pr="sm"
-                            style={{ flex: '0 0 auto', minWidth: 'max-content' }}
-                          >
-                            <Group gap="xs" wrap="wrap" justify="flex-start">
-                              {stopLevelRealtimeBuses.map((bus) => (
-                                <RouteRealtimeBadge
-                                  key={bus.id}
-                                  buttonRef={(node) => setVehicleBadgeRef(bus.id, node)}
-                                  isSelected={bus.id === selectedVehicleId}
-                                  plateNumb={bus.plateNumb}
-                                  onClick={(event) => {
-                                    event.stopPropagation()
-                                    onSelectVehicle(bus.id)
-                                  }}
-                                />
-                              ))}
-                            </Group>
                             <ActionIcon
                               variant="light"
                               color={stop.isFavorite ? 'pink' : 'gray'}
@@ -245,8 +222,33 @@ export const RouteStopList = ({
                             >
                               {stop.isFavorite ? <RiHeart2Fill /> : <RiHeart2Line />}
                             </ActionIcon>
-                          </Stack>
-                        </Group>
+                          </Group>
+                          {(stop.estimatedArrivalLabel || stopLevelRealtimeBuses.length > 0) && (
+                            <Group justify="space-between" align="center" wrap="nowrap">
+                              <Box style={{ flex: 1, minWidth: 0 }}>
+                                {stop.estimatedArrivalLabel && (
+                                  <Text size="xs" c="dimmed">
+                                    {stop.estimatedArrivalLabel}
+                                  </Text>
+                                )}
+                              </Box>
+                              <Group gap="xs" wrap="wrap" justify="flex-end" pr="xl" style={{ flexShrink: 0 }}>
+                                {stopLevelRealtimeBuses.map((bus) => (
+                                  <RouteRealtimeBadge
+                                    key={bus.id}
+                                    buttonRef={(node) => setVehicleBadgeRef(bus.id, node)}
+                                    isSelected={bus.id === selectedVehicleId}
+                                    plateNumb={bus.plateNumb}
+                                    onClick={(event) => {
+                                      event.stopPropagation()
+                                      onSelectVehicle(bus.id)
+                                    }}
+                                  />
+                                ))}
+                              </Group>
+                            </Group>
+                          )}
+                        </Stack>
                       </Box>
                     )}
                   >

--- a/app/pages/Route.test.tsx
+++ b/app/pages/Route.test.tsx
@@ -604,7 +604,7 @@ describe('Route', () => {
     })
   })
 
-  it('selects the matching stop in the list when clicking a vehicle marker on the map', async () => {
+  it('selects only the vehicle in the list when clicking a vehicle marker on the map', async () => {
     renderRoutePage()
 
     fireEvent.click(screen.getByRole('tab', { name: '返程' }))
@@ -629,7 +629,7 @@ describe('Route', () => {
         | undefined
       const latestRouteMapProps = updatedCall?.[0]
 
-      expect(latestRouteMapProps?.selectedStop).toBe('stop-c')
+      expect(latestRouteMapProps?.selectedStop).toBeNull()
       expect(latestRouteMapProps?.selectedVehicleId).toBe('ABC-123')
     })
   })

--- a/app/pages/Route.tsx
+++ b/app/pages/Route.tsx
@@ -140,10 +140,8 @@ export default function Route() {
   const handleSelectVehicleFromMap = useCallback((vehicleId: string) => {
     setListScrollBehavior('start')
     setSelectedVehicleId(vehicleId)
-    setSelectedStopId(
-      timelineStops.find((stop) => stop.realtimeBuses.some((bus) => bus.id === vehicleId))?.id ?? null
-    )
-  }, [timelineStops])
+    setSelectedStopId(null)
+  }, [])
 
   const handleSelectStopFromMap = useCallback((stopId: string | null) => {
     setListScrollBehavior('start')


### PR DESCRIPTION
## Summary

Improve the route page stop-list experience by stabilizing realtime vehicle badge layout and aligning list selection behavior with map-driven vehicle selection.

## What Changed

- reworked route stop rows into a two-line layout so stop names and favorite actions stay on the title row, while ETA text and stop-level vehicle badges share a secondary row
- clamped long stop names to a single line with ellipsis to avoid awkward wrapping
- removed the old gap padding hack that relied on an undefined CSS variable and replaced it with explicit layout structure
- added badge refs so selected vehicles can scroll the list to the actual realtime badge instead of approximating with the stop row
- changed map vehicle selection to select only the vehicle, without also selecting the containing stop row
- stabilized route stop list scroll-effect dependencies so favorite toggles do not retrigger selected-item scrolling and jump the timeline viewport
- updated `Route.test.tsx` to match the new map vehicle selection behavior

## Validation

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`

## Scope Notes

This PR focuses only on the route stop list and related vehicle-selection behavior on the route page.
It does not change realtime matching logic, route data fetching, or map marker rendering beyond the selected stop / selected vehicle state wiring.

## Reviewer Notes

Please pay extra attention to these flows:

- route stop list layout when a stop has one or multiple stop-level vehicle badges
- gap badge alignment relative to the favorite action column
- clicking a vehicle badge in the list
- clicking a vehicle marker on the map and confirming the list scrolls to the selected vehicle badge without selecting the stop row
- toggling favorites inside the timeline and confirming the scroll position no longer jumps
