### PR TITLE
feat(route): show ETA in the mobile route stop popup

### DIFF
--- a/app/components/common/BaseMap.tsx
+++ b/app/components/common/BaseMap.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import type { LatLng } from '~/modules/types/CoordsType'
 import type { RootState } from '~/modules/store'
+import { toLngLat } from '~/modules/utils/geo/convertCoordinates'
 import { createMapMarkerElement } from '~/modules/utils/map/createMapMarkerElement'
 import { APP_FLOATING_ACTION_OFFSET } from '~/modules/consts/layout'
 
@@ -30,6 +31,8 @@ const BaseMap = ({ center, zoom = 16, showUserLocation = false, extraControls, o
   const onLoadRef = useRef(onLoad)
 
   const { coords } = useSelector((state: RootState) => state.geolocation)
+  const mapCenter = center ? toLngLat(center) : null
+  const userLngLat = coords ? toLngLat(coords) : null
 
   useEffect(() => {
     onLoadRef.current = onLoad
@@ -39,7 +42,7 @@ const BaseMap = ({ center, zoom = 16, showUserLocation = false, extraControls, o
     const mapInstance = new mapLibre.Map({
       container: id,
       style: 'https://tiles.openfreemap.org/styles/positron',
-      center: center ? [center[1], center[0]] : [121.53969560512759, 25.059928238479156],
+      center: mapCenter ?? [121.53969560512759, 25.059928238479156],
       zoom
     })
     setMap(mapInstance)
@@ -64,15 +67,15 @@ const BaseMap = ({ center, zoom = 16, showUserLocation = false, extraControls, o
     if (!map || !center || initialCenterRef.current) return
 
     map.flyTo({
-      center: new MapLngLat(center[1], center[0]),
+      center: new MapLngLat(mapCenter![0], mapCenter![1]),
       zoom,
       duration: 800
     })
     initialCenterRef.current = true
-  }, [center, map, zoom])
+  }, [center, map, mapCenter, zoom])
 
   useEffect(() => {
-    if (!map || !coords || !showUserLocation) return
+    if (!map || !userLngLat || !showUserLocation) return
 
     if (userMarkerRef.current) {
       userMarkerRef.current.remove()
@@ -86,14 +89,14 @@ const BaseMap = ({ center, zoom = 16, showUserLocation = false, extraControls, o
     })
 
     userMarkerRef.current = new Marker({ element: el })
-      .setLngLat(new MapLngLat(coords![1], coords![0]))
+      .setLngLat(new MapLngLat(userLngLat[0], userLngLat[1]))
       .addTo(map!)
 
     return () => {
       userMarkerRef.current?.remove()
       userMarkerRef.current = null
     }
-  }, [coords, map, showUserLocation, t])
+  }, [map, showUserLocation, t, userLngLat])
 
   return (
     <Box pos="relative" style={{ width: '100%', height: '100%' }}>
@@ -113,15 +116,15 @@ const BaseMap = ({ center, zoom = 16, showUserLocation = false, extraControls, o
               aria-label={t('components.baseMap.focusUserLocationAriaLabel')}
               size="md"
               onClick={() => {
-                if (!map || !coords) return
+                if (!map || !userLngLat) return
 
                 map.flyTo({
-                  center: [coords[1], coords[0]],
+                  center: userLngLat,
                   zoom: FOCUS_ZOOM,
                   duration: 800
                 })
               }}
-              disabled={!coords || !map}
+              disabled={!userLngLat || !map}
             >
               <RiFocus3Line size={18} />
             </ActionIcon>

--- a/app/components/common/BaseMap.tsx
+++ b/app/components/common/BaseMap.tsx
@@ -3,7 +3,7 @@ import { useId } from '@mantine/hooks'
 import mapLibre, { Map, Marker, LngLat as MapLngLat } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import { RiFocus3Line } from '@remixicon/react'
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import type { LatLng } from '~/modules/types/CoordsType'
@@ -31,8 +31,8 @@ const BaseMap = ({ center, zoom = 16, showUserLocation = false, extraControls, o
   const onLoadRef = useRef(onLoad)
 
   const { coords } = useSelector((state: RootState) => state.geolocation)
-  const mapCenter = center ? toLngLat(center) : null
-  const userLngLat = coords ? toLngLat(coords) : null
+  const mapCenter = useMemo(() => (center ? toLngLat(center) : null), [center])
+  const userLngLat = useMemo(() => (coords ? toLngLat(coords) : null), [coords])
 
   useEffect(() => {
     onLoadRef.current = onLoad

--- a/app/components/common/StopDistanceText.tsx
+++ b/app/components/common/StopDistanceText.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import type { RootState } from '~/modules/store'
 import type { LngLat } from '~/modules/types/CoordsType'
+import { toLngLat } from '~/modules/utils/geo/convertCoordinates'
 
 interface PropType extends Omit<TextProps, 'children'> {
   position: LngLat | null
@@ -20,7 +21,7 @@ export const StopDistanceText = ({ position, ...textProps }: PropType) => {
       return null
     }
 
-    return distance(point([coords[1], coords[0]]), point(position), {
+    return distance(point(toLngLat(coords)!), point(position), {
       units: 'kilometers'
     })
   }, [coords, position])

--- a/app/components/nearby/NearbySidebarContent.tsx
+++ b/app/components/nearby/NearbySidebarContent.tsx
@@ -11,6 +11,7 @@ import type { AlertMessageConfig } from '~/modules/interfaces/AlertMessageConfig
 import type { NearbyStopGroup } from '~/modules/interfaces/Nearby'
 import type { StationRoute } from '~/modules/interfaces/StationRoute'
 import { selectLocale } from '~/modules/slices/localeSlice'
+import { toLatLng } from '~/modules/utils/geo/convertCoordinates'
 import { getCityTranslationKey } from '~/modules/utils/i18n/getCityTranslationKey'
 import { getLocalizedText } from '~/modules/utils/i18n/getLocalizedText'
 import { NearbyStopDetail } from './NearbyStopDetail'
@@ -69,7 +70,7 @@ const NearbySidebarContentDetail = ({ detailState }: { detailState: NearbySideba
               ariaLabel={t('components.routeStopList.navigateAriaLabel', {
                 stopName: getLocalizedText(detailState.stopGroup!.StopName, locale)
               })}
-              destination={[detailState.stopGroup!.position[1], detailState.stopGroup!.position[0]]}
+              destination={toLatLng(detailState.stopGroup!.position)}
             />
           </Group>
         </Stack>

--- a/app/components/nearby/NearbyStopDetail.tsx
+++ b/app/components/nearby/NearbyStopDetail.tsx
@@ -8,6 +8,7 @@ import { StopDistanceText } from '~/components/common/StopDistanceText'
 import type { NearbyStopGroup } from '~/modules/interfaces/Nearby'
 import type { StationRoute } from '~/modules/interfaces/StationRoute'
 import { selectLocale } from '~/modules/slices/localeSlice'
+import { toLatLng } from '~/modules/utils/geo/convertCoordinates'
 import { getCityTranslationKey } from '~/modules/utils/i18n/getCityTranslationKey'
 import { getLocalizedText } from '~/modules/utils/i18n/getLocalizedText'
 
@@ -29,7 +30,7 @@ export const NearbyStopDetail = ({
   const { t } = useTranslation()
   const locale = useSelector(selectLocale)
   const stopName = getLocalizedText(stopGroup.StopName, locale)
-  const destination: [number, number] = [stopGroup.position[1], stopGroup.position[0]]
+  const destination = toLatLng(stopGroup.position)!
 
   if (displayMode === 'title') {
     return (

--- a/app/components/route/RouteMap.test.tsx
+++ b/app/components/route/RouteMap.test.tsx
@@ -180,6 +180,42 @@ describe('RouteMap', () => {
     expect(screen.getByRole('button', { name: /導航至\s*市政府/ })).toBeInTheDocument()
   })
 
+  it('renders custom selected stop popup content when provided', async () => {
+    const store = createTestStore({
+      reducer: {
+        geolocation: geoSlice.reducer
+      },
+      preloadedState: {
+        geolocation: {
+          ...geoSlice.getInitialState(),
+          coords: [25.033, 121.5654],
+          error: null
+        }
+      }
+    })
+
+    renderWithStore(
+      <RouteMap
+        isSm
+        onSelectStop={vi.fn()}
+        onSelectVehicle={vi.fn()}
+        selectedStop="stop-1"
+        selectedStopPopupContent={<div>3 分鐘</div>}
+        stops={[{
+          id: 'stop-1',
+          name: '市政府',
+          position: [121.55, 25.03],
+          sequence: 1
+        }]}
+        vehicles={[]}
+      />,
+      { store }
+    )
+
+    expect(await screen.findByText('3 分鐘')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /導航至\s*市政府/ })).not.toBeInTheDocument()
+  })
+
   it('fits the initial bounds again when the route changes', async () => {
     const store = createTestStore({
       reducer: {

--- a/app/components/route/RouteMap.test.tsx
+++ b/app/components/route/RouteMap.test.tsx
@@ -165,6 +165,7 @@ describe('RouteMap', () => {
         onSelectStop={vi.fn()}
         onSelectVehicle={vi.fn()}
         selectedStop="stop-1"
+        selectedStopEstimatedArrivalLabel="3 分鐘"
         stops={[{
           id: 'stop-1',
           name: '市政府',
@@ -177,43 +178,8 @@ describe('RouteMap', () => {
     )
 
     expect(await screen.findByText('市政府')).toBeInTheDocument()
+    expect(screen.getByText('3 分鐘')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /導航至\s*市政府/ })).toBeInTheDocument()
-  })
-
-  it('renders custom selected stop popup content when provided', async () => {
-    const store = createTestStore({
-      reducer: {
-        geolocation: geoSlice.reducer
-      },
-      preloadedState: {
-        geolocation: {
-          ...geoSlice.getInitialState(),
-          coords: [25.033, 121.5654],
-          error: null
-        }
-      }
-    })
-
-    renderWithStore(
-      <RouteMap
-        isSm
-        onSelectStop={vi.fn()}
-        onSelectVehicle={vi.fn()}
-        selectedStop="stop-1"
-        selectedStopPopupContent={<div>3 分鐘</div>}
-        stops={[{
-          id: 'stop-1',
-          name: '市政府',
-          position: [121.55, 25.03],
-          sequence: 1
-        }]}
-        vehicles={[]}
-      />,
-      { store }
-    )
-
-    expect(await screen.findByText('3 分鐘')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /導航至\s*市政府/ })).not.toBeInTheDocument()
   })
 
   it('fits the initial bounds again when the route changes', async () => {

--- a/app/components/route/RouteMap.tsx
+++ b/app/components/route/RouteMap.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack, Text } from '@mantine/core'
+import { Stack, Text } from '@mantine/core'
 import type { Map as MapLibreMap, Marker, Popup } from 'maplibre-gl'
 import mapLibre from 'maplibre-gl'
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
@@ -8,7 +8,7 @@ import type { LngLat, LatLng } from '~/modules/types/CoordsType'
 import { addMapMarkerActivationListeners } from '~/modules/utils/map/addMapMarkerActivationListeners'
 import { createMapMarkerElement } from '~/modules/utils/map/createMapMarkerElement'
 import BaseMap from '../common/BaseMap'
-import { NavigationButton } from '../common/NavigationButton'
+import { RoutePopupContent } from './RoutePopupContent'
 
 export interface RouteMapStop {
   id: string
@@ -33,7 +33,7 @@ interface PropType {
   onSelectVehicle: (vehicleId: string) => void
   routePath?: LngLat[]
   selectedStop: string | null
-  selectedStopPopupContent?: ReactNode
+  selectedStopEstimatedArrivalLabel?: string | null
   selectedVehicleId?: string | null
   stops: RouteMapStop[]
   vehicles?: RouteMapVehicle[]
@@ -62,7 +62,7 @@ export const RouteMap = ({
   onSelectVehicle,
   routePath = [],
   selectedStop,
-  selectedStopPopupContent,
+  selectedStopEstimatedArrivalLabel = null,
   selectedVehicleId = null,
   stops,
   vehicles = []
@@ -380,27 +380,12 @@ export const RouteMap = ({
         )
         : popupContainer && selectedMapStop
           ? createPortal(
-            selectedStopPopupContent
-              ? selectedStopPopupContent
-              : isSm
-              ? (
-                <Group align="center" wrap="nowrap" gap="xs" style={{ minWidth: 0, maxWidth: '100%' }}>
-                  <Text size="sm" fw={500} style={{ minWidth: 0, flex: '0 1 auto' }} lineClamp={1}>
-                    {selectedMapStop.name}
-                  </Text>
-                  <NavigationButton
-                    ariaLabel={t('components.routeStopList.navigateAriaLabel', {
-                      stopName: selectedMapStop.name
-                    })}
-                    destination={[selectedMapStop.position[1], selectedMapStop.position[0]]}
-                  />
-                </Group>
-                )
-              : (
-                <Text size="sm" fw={500} style={{ flex: 1, minWidth: 0 }} lineClamp={1}>
-                  {selectedMapStop.name}
-                </Text>
-                ),
+            <RoutePopupContent
+              isSm={isSm}
+              stopName={selectedMapStop.name}
+              estimatedArrivalLabel={selectedStopEstimatedArrivalLabel}
+              position={selectedMapStop.position}
+            />,
             popupContainer
           )
         : null}

--- a/app/components/route/RouteMap.tsx
+++ b/app/components/route/RouteMap.tsx
@@ -4,7 +4,8 @@ import mapLibre from 'maplibre-gl'
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
-import type { LngLat, LatLng } from '~/modules/types/CoordsType'
+import type { LngLat } from '~/modules/types/CoordsType'
+import { toLatLng } from '~/modules/utils/geo/convertCoordinates'
 import { addMapMarkerActivationListeners } from '~/modules/utils/map/addMapMarkerActivationListeners'
 import { createMapMarkerElement } from '~/modules/utils/map/createMapMarkerElement'
 import BaseMap from '../common/BaseMap'
@@ -98,9 +99,7 @@ export const RouteMap = ({
   const selectedVehicle = selectedVehicleId ? vehiclesById.get(selectedVehicleId) ?? null : null
   const selectedMapStop = selectedStop ? stopsById.get(selectedStop) ?? null : null
 
-  const center = positionedStops[0]
-    ? [positionedStops[0].position[1], positionedStops[0].position[0]] as LatLng
-    : null
+  const center = positionedStops[0] ? toLatLng(positionedStops[0].position) : null
 
   useEffect(() => {
     if (!map) {

--- a/app/components/route/RouteMap.tsx
+++ b/app/components/route/RouteMap.tsx
@@ -33,6 +33,7 @@ interface PropType {
   onSelectVehicle: (vehicleId: string) => void
   routePath?: LngLat[]
   selectedStop: string | null
+  selectedStopPopupContent?: ReactNode
   selectedVehicleId?: string | null
   stops: RouteMapStop[]
   vehicles?: RouteMapVehicle[]
@@ -61,6 +62,7 @@ export const RouteMap = ({
   onSelectVehicle,
   routePath = [],
   selectedStop,
+  selectedStopPopupContent,
   selectedVehicleId = null,
   stops,
   vehicles = []
@@ -378,7 +380,9 @@ export const RouteMap = ({
         )
         : popupContainer && selectedMapStop
           ? createPortal(
-            isSm
+            selectedStopPopupContent
+              ? selectedStopPopupContent
+              : isSm
               ? (
                 <Group align="center" wrap="nowrap" gap="xs" style={{ minWidth: 0, maxWidth: '100%' }}>
                   <Text size="sm" fw={500} style={{ minWidth: 0, flex: '0 1 auto' }} lineClamp={1}>

--- a/app/components/route/RoutePopupContent.tsx
+++ b/app/components/route/RoutePopupContent.tsx
@@ -1,0 +1,34 @@
+import { Group, Stack, Text } from '@mantine/core'
+import { NavigationButton } from '../common/NavigationButton'
+import { useTranslation } from 'react-i18next'
+import { getLatLng } from '~/modules/utils/geo/position'
+import type { LngLat } from '~/modules/types/CoordsType'
+
+export const RoutePopupContent: React.FC<{
+    stopName: string
+    estimatedArrivalLabel: string | null
+    position: LngLat | null
+    isSm: boolean
+}> = ({ stopName, estimatedArrivalLabel, position, isSm }) => {
+  const { t } = useTranslation()
+  return (
+    <Group align="center" gap="xs" wrap="nowrap" style={{ minWidth: 0, maxWidth: '100%' }}>
+      <Stack gap={2} style={{ minWidth: 0, flex: 1 }}>
+        <Text size="sm" fw={500} lineClamp={1}>
+          {stopName}
+        </Text>
+        <NavigationButton
+          ariaLabel={t('components.routeStopList.navigateAriaLabel', {
+            stopName
+          })}
+          destination={getLatLng(position)}
+        />
+      </Stack>
+      {isSm && estimatedArrivalLabel && (
+        <Text size="xs" c="dimmed">
+            {estimatedArrivalLabel}
+        </Text>
+      )}
+    </Group>
+  )
+}

--- a/app/components/route/RoutePopupContent.tsx
+++ b/app/components/route/RoutePopupContent.tsx
@@ -12,25 +12,26 @@ export const RoutePopupContent: React.FC<{
 }> = ({ stopName, estimatedArrivalLabel, position, isSm }) => {
   const { t } = useTranslation()
   return (
-    <Group align="center" gap="xs" wrap="nowrap" style={{ minWidth: 0, maxWidth: '100%' }}>
-      <Stack gap={2} style={{ minWidth: 0, flex: 1 }}>
-        <Text size="sm" fw={500} lineClamp={1}>
+    <Stack gap={2}>
+      <Group align="center" gap="xs" wrap="nowrap">
+        <Text size="sm" fw={500} lineClamp={1} style={{ minWidth: 0, maxWidth: '100%' }}>
           {stopName}
         </Text>
-        {isSm && estimatedArrivalLabel && (
-          <Text size="xs" c="dimmed" lineClamp={1}>
-            {estimatedArrivalLabel}
-          </Text>
+        {isSm && (
+          <NavigationButton
+            ariaLabel={t('components.routeStopList.navigateAriaLabel', {
+              stopName
+            })}
+            destination={toLatLng(position)}
+            size="xs"
+          />
         )}
-      </Stack>
-      {isSm && (
-        <NavigationButton
-          ariaLabel={t('components.routeStopList.navigateAriaLabel', {
-            stopName
-          })}
-          destination={toLatLng(position)}
-        />
+      </Group>
+      {isSm && estimatedArrivalLabel && (
+        <Text size="xs" c="dimmed" lineClamp={1}>
+          {estimatedArrivalLabel}
+        </Text>
       )}
-    </Group>
+    </Stack>
   )
 }

--- a/app/components/route/RoutePopupContent.tsx
+++ b/app/components/route/RoutePopupContent.tsx
@@ -1,14 +1,14 @@
 import { Group, Stack, Text } from '@mantine/core'
 import { NavigationButton } from '../common/NavigationButton'
 import { useTranslation } from 'react-i18next'
-import { getLatLng } from '~/modules/utils/geo/position'
+import { toLatLng } from '~/modules/utils/geo/convertCoordinates'
 import type { LngLat } from '~/modules/types/CoordsType'
 
 export const RoutePopupContent: React.FC<{
-    stopName: string
-    estimatedArrivalLabel: string | null
-    position: LngLat | null
-    isSm: boolean
+  stopName: string
+  estimatedArrivalLabel: string | null
+  position: LngLat | null
+  isSm: boolean
 }> = ({ stopName, estimatedArrivalLabel, position, isSm }) => {
   const { t } = useTranslation()
   return (
@@ -17,17 +17,19 @@ export const RoutePopupContent: React.FC<{
         <Text size="sm" fw={500} lineClamp={1}>
           {stopName}
         </Text>
+        {isSm && estimatedArrivalLabel && (
+          <Text size="xs" c="dimmed" lineClamp={1}>
+            {estimatedArrivalLabel}
+          </Text>
+        )}
+      </Stack>
+      {isSm && (
         <NavigationButton
           ariaLabel={t('components.routeStopList.navigateAriaLabel', {
             stopName
           })}
-          destination={getLatLng(position)}
+          destination={toLatLng(position)}
         />
-      </Stack>
-      {isSm && estimatedArrivalLabel && (
-        <Text size="xs" c="dimmed">
-            {estimatedArrivalLabel}
-        </Text>
       )}
     </Group>
   )

--- a/app/components/route/RouteStopList.tsx
+++ b/app/components/route/RouteStopList.tsx
@@ -8,6 +8,7 @@ import { useScrollSelectedItem } from '~/modules/hooks/useScrollSelectedItem'
 import type { FavoriteRouteStop } from '~/modules/interfaces/FavoriteRouteStop'
 import type { RouteRealtimeBusStatus } from '~/modules/interfaces/RouteRealtimeBusStatus'
 import { VehicleStateType } from '~/modules/enums/VehicleStateType'
+import { toLatLng } from '~/modules/utils/geo/convertCoordinates'
 import { SkeletonList } from '../common/SkeletonList'
 import { RouteRealtimeBadge } from './RouteRealtimeBadge'
 import { RouteRealtimeGap } from './RouteRealtimeGap'
@@ -216,7 +217,7 @@ export const RouteStopList = ({
                                 ariaLabel={t('components.routeStopList.navigateAriaLabel', {
                                   stopName: stop.name
                                 })}
-                                destination={stop.position ? [stop.position[1], stop.position[0]] : null}
+                                destination={toLatLng(stop.position ?? null)}
                               />
                             </Group>
                             <ActionIcon

--- a/app/modules/hooks/useNearbyData.ts
+++ b/app/modules/hooks/useNearbyData.ts
@@ -22,6 +22,7 @@ import { useLocalizedTextCollator } from '~/modules/hooks/useLocalizedTextCollat
 import { selectLocale } from '~/modules/slices/localeSlice'
 import type { RootState } from '~/modules/store'
 import { getCityByCoords } from '~/modules/utils/geo/getCityByCoords'
+import { toLngLat } from '~/modules/utils/geo/convertCoordinates'
 import { getLocalizedText } from '~/modules/utils/i18n/getLocalizedText'
 import { normalizeBusRoutesWithDates } from '~/modules/utils/route/normalizeBusRoutesWithDates'
 
@@ -38,7 +39,7 @@ function groupNearbyStops(
 ): NearbyStopGroup[] {
   if (!coords || !isSuccess || !allStops) return []
 
-  const currentPoint = point([coords[1], coords[0]])
+  const currentPoint = point(toLngLat(coords)!)
   const groupedStops = new Map<string, NearbyStopGroup>()
 
   allStops.forEach((stop) => {

--- a/app/modules/hooks/useRouteBaseData.ts
+++ b/app/modules/hooks/useRouteBaseData.ts
@@ -21,7 +21,7 @@ export interface RouteTab {
   direction: DirectionType
 }
 
-export interface RouteBaseTimelineStop {
+export interface RouteBaseStop {
   favoriteRouteStop: FavoriteRouteStop
   id: string
   isFavorite: boolean
@@ -147,7 +147,7 @@ export function useRouteBaseData(
     }, new Map())
   }, [stopsByCity])
 
-  const baseTimelineStops = useMemo<RouteBaseTimelineStop[]>(() => {
+  const baseStops = useMemo<RouteBaseStop[]>(() => {
     if (!activeStopOfRoute || !activeSubRoute || !busRoute) return []
 
     return activeStopOfRoute.Stops.map((stop) => {
@@ -225,7 +225,7 @@ export function useRouteBaseData(
 
   return {
     activeSubRoute,
-    baseTimelineStops,
+    baseStops,
     busRoute,
     highlightedStopId,
     isLoading,

--- a/app/modules/utils/geo/convertCoordinates.test.ts
+++ b/app/modules/utils/geo/convertCoordinates.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { toLatLng, toLngLat } from './convertCoordinates'
+
+describe('convertCoordinates', () => {
+  it('converts lng-lat tuples into lat-lng tuples', () => {
+    expect(toLatLng([121.5654, 25.033])).toEqual([25.033, 121.5654])
+  })
+
+  it('converts lat-lng tuples into lng-lat tuples', () => {
+    expect(toLngLat([25.033, 121.5654])).toEqual([121.5654, 25.033])
+  })
+
+  it('returns null when coordinates are missing', () => {
+    expect(toLatLng(null)).toBeNull()
+    expect(toLngLat(null)).toBeNull()
+  })
+})

--- a/app/modules/utils/geo/convertCoordinates.ts
+++ b/app/modules/utils/geo/convertCoordinates.ts
@@ -1,6 +1,6 @@
 import type { LatLng, LngLat } from '~/modules/types/CoordsType'
 
-export const getLatLng = (position: LngLat | null): LatLng | null => {
+export const toLatLng = (position: LngLat | null): LatLng | null => {
   if (!position) {
     return null
   }
@@ -8,7 +8,7 @@ export const getLatLng = (position: LngLat | null): LatLng | null => {
   return [position[1], position[0]]
 }
 
-export const getLngLat = (position: LatLng | null): LngLat | null => {
+export const toLngLat = (position: LatLng | null): LngLat | null => {
   if (!position) {
     return null
   }

--- a/app/modules/utils/geo/position.ts
+++ b/app/modules/utils/geo/position.ts
@@ -1,0 +1,17 @@
+import type { LatLng, LngLat } from '~/modules/types/CoordsType'
+
+export const getLatLng = (position: LngLat | null): LatLng | null => {
+  if (!position) {
+    return null
+  }
+
+  return [position[1], position[0]]
+}
+
+export const getLngLat = (position: LatLng | null): LngLat | null => {
+  if (!position) {
+    return null
+  }
+
+  return [position[1], position[0]]
+}

--- a/app/pages/Route.tsx
+++ b/app/pages/Route.tsx
@@ -18,7 +18,6 @@ import { getTerminalDisplay } from '~/modules/utils/i18n/getTerminalDisplay'
 import { getLocalizedText } from '~/modules/utils/i18n/getLocalizedText'
 import { saveRouteSearchRecent } from '~/modules/utils/routes/routeSearchRecentStorage'
 import { isCityName } from '~/modules/utils/shared/isCityName'
-import { RoutePopupContent } from '~/components/route/RoutePopupContent'
 
 export default function Route() {
   const { t } = useTranslation()
@@ -80,8 +79,8 @@ export default function Route() {
       null,
     realtimeBuses: realtimeBusesByStopSequence.get(stop.sequence) ?? []
   })), [baseStops, estimatedArrivalLabelsByStopKey, realtimeBusesByStopSequence])
-  const selectedMapStop = useMemo(
-    () => stops.find((stop) => stop.id === selectedStopId) ?? null,
+  const selectedStopEstimatedArrivalLabel = useMemo(
+    () => stops.find((stop) => stop.id === selectedStopId)?.estimatedArrivalLabel ?? null,
     [selectedStopId, stops]
   )
   const routeName = busRoute ? getLocalizedText(busRoute.RouteName, locale) : null
@@ -273,14 +272,7 @@ export default function Route() {
         onSelectVehicle={handleSelectVehicleFromMap}
         routePath={activeRoutePath}
         stops={routeMapStops}
-        selectedStopPopupContent={selectedMapStop ? (
-          <RoutePopupContent
-            isSm={isSm}
-            stopName={selectedMapStop.name}
-            estimatedArrivalLabel={selectedMapStop.estimatedArrivalLabel}
-            position={selectedMapStop.position}
-          />
-        ) : null}
+        selectedStopEstimatedArrivalLabel={selectedStopEstimatedArrivalLabel}
         vehicles={realtimeMapVehicles}
       />
     </MapSidebarLayout>

--- a/app/pages/Route.tsx
+++ b/app/pages/Route.tsx
@@ -44,7 +44,7 @@ export default function Route() {
     : null
   const {
     activeSubRoute,
-    baseTimelineStops,
+    baseStops,
     busRoute,
     highlightedStopId,
     isLoading,
@@ -72,13 +72,13 @@ export default function Route() {
     realtimeBusesByStopSequence,
     realtimeInfoState
   } = useRouteRealtimeData(routeRealtimeOptions)
-  const timelineStops = useMemo(() => baseTimelineStops.map((stop) => ({
+  const stops = useMemo(() => baseStops.map((stop) => ({
     ...stop,
     estimatedArrivalLabel: estimatedArrivalLabelsByStopKey.get(stop.id) ??
       estimatedArrivalLabelsByStopKey.get(stop.stopID) ??
       null,
     realtimeBuses: realtimeBusesByStopSequence.get(stop.sequence) ?? []
-  })), [baseTimelineStops, estimatedArrivalLabelsByStopKey, realtimeBusesByStopSequence])
+  })), [baseStops, estimatedArrivalLabelsByStopKey, realtimeBusesByStopSequence])
   const routeName = busRoute ? getLocalizedText(busRoute.RouteName, locale) : null
   const routeDeparture = busRoute ? getLocalizedText(busRoute.DepartureStopName, locale) : null
   const routeDestination = busRoute ? getLocalizedText(busRoute.DestinationStopName, locale) : null
@@ -115,17 +115,17 @@ export default function Route() {
 
   useEffect(() => {
     if (!selectedStopId) return
-    if (timelineStops.some((stop) => stop.id === selectedStopId)) return
+    if (stops.some((stop) => stop.id === selectedStopId)) return
 
     setSelectedStopId(null)
-  }, [selectedStopId, timelineStops])
+  }, [selectedStopId, stops])
 
   useEffect(() => {
     if (!selectedVehicleId) return
-    if (timelineStops.some((stop) => stop.realtimeBuses.some((bus) => bus.id === selectedVehicleId))) return
+    if (stops.some((stop) => stop.realtimeBuses.some((bus) => bus.id === selectedVehicleId))) return
 
     setSelectedVehicleId(null)
-  }, [selectedVehicleId, timelineStops])
+  }, [selectedVehicleId, stops])
 
   const handleSelectStopFromList = useCallback((stopId: string) => {
     setListScrollBehavior('nearest')
@@ -232,7 +232,7 @@ export default function Route() {
                     onSelectStop={handleSelectStopFromList}
                     onSelectVehicle={handleSelectVehicleFromList}
                     realtimeInfoState={realtimeInfoState}
-                    stops={timelineStops}
+                    stops={stops}
                     onToggleFavorite={toggleFavoriteRouteStop}
                     selectedStopId={selectedStopId}
                     selectedVehicleId={selectedVehicleId}

--- a/app/pages/Route.tsx
+++ b/app/pages/Route.tsx
@@ -18,6 +18,7 @@ import { getTerminalDisplay } from '~/modules/utils/i18n/getTerminalDisplay'
 import { getLocalizedText } from '~/modules/utils/i18n/getLocalizedText'
 import { saveRouteSearchRecent } from '~/modules/utils/routes/routeSearchRecentStorage'
 import { isCityName } from '~/modules/utils/shared/isCityName'
+import { RoutePopupContent } from '~/components/route/RoutePopupContent'
 
 export default function Route() {
   const { t } = useTranslation()
@@ -79,6 +80,10 @@ export default function Route() {
       null,
     realtimeBuses: realtimeBusesByStopSequence.get(stop.sequence) ?? []
   })), [baseStops, estimatedArrivalLabelsByStopKey, realtimeBusesByStopSequence])
+  const selectedMapStop = useMemo(
+    () => stops.find((stop) => stop.id === selectedStopId) ?? null,
+    [selectedStopId, stops]
+  )
   const routeName = busRoute ? getLocalizedText(busRoute.RouteName, locale) : null
   const routeDeparture = busRoute ? getLocalizedText(busRoute.DepartureStopName, locale) : null
   const routeDestination = busRoute ? getLocalizedText(busRoute.DestinationStopName, locale) : null
@@ -268,6 +273,14 @@ export default function Route() {
         onSelectVehicle={handleSelectVehicleFromMap}
         routePath={activeRoutePath}
         stops={routeMapStops}
+        selectedStopPopupContent={selectedMapStop ? (
+          <RoutePopupContent
+            isSm={isSm}
+            stopName={selectedMapStop.name}
+            estimatedArrivalLabel={selectedMapStop.estimatedArrivalLabel}
+            position={selectedMapStop.position}
+          />
+        ) : null}
         vehicles={realtimeMapVehicles}
       />
     </MapSidebarLayout>


### PR DESCRIPTION
## Related

- Closes #27 

## Summary

Show ETA in the mobile stop popup on the Route page while keeping the desktop popup unchanged and reusing the existing route ETA data.

## What Changed

- Add mobile Route map popup ETA display with compact stop name + ETA content.
- Keep popup rendering inside RouteMap and pass only the selected stop ETA from Route.
- Add shared coordinate conversion helpers and replace repeated manual lat/lng swaps in touched route, nearby, and map code.
- Update Route map popup tests and add helper tests.

## Validation

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`

## Scope Notes

- Desktop Route popup stays unchanged.
- No popup-specific fetching or duplicate ETA matching was added.

## Reviewer Notes

- Beyond the original issue, this PR also cleans up popup ownership in RouteMap and centralizes coordinate tuple conversion.