### PR TITLE
feat(route): improve route data flow and nearby stop direction clarity

### DIFF
--- a/app/components/nearby/NearbySidebarContent.tsx
+++ b/app/components/nearby/NearbySidebarContent.tsx
@@ -14,6 +14,7 @@ import { selectLocale } from '~/modules/slices/localeSlice'
 import { toLatLng } from '~/modules/utils/geo/convertCoordinates'
 import { getCityTranslationKey } from '~/modules/utils/i18n/getCityTranslationKey'
 import { getLocalizedText } from '~/modules/utils/i18n/getLocalizedText'
+import { getStopGroupBearingLabel } from '~/modules/utils/nearby/getStopGroupBearingLabel'
 import { NearbyStopDetail } from './NearbyStopDetail'
 import { NearbyStopRoutes } from './NearbyStopRoutes'
 
@@ -51,6 +52,7 @@ interface PropType {
 const NearbySidebarContentDetail = ({ detailState }: { detailState: NearbySidebarDetailState }) => {
   const { t } = useTranslation()
   const locale = useSelector(selectLocale)
+  const stopBearingLabel = getStopGroupBearingLabel(t, detailState.stopGroup!)
 
   return (
     <Stack gap="md" style={{ flex: 1, minHeight: 0 }}>
@@ -64,6 +66,9 @@ const NearbySidebarContentDetail = ({ detailState }: { detailState: NearbySideba
         <Title order={4} style={{ flex: 1, minWidth: 0 }} lineClamp={1}>
           {getLocalizedText(detailState.stopGroup!.StopName, locale)}
         </Title>
+        {stopBearingLabel && (
+          <Text size="sm" c="dimmed">{stopBearingLabel}</Text>
+        )}
       </Flex>
       <Stack gap="md" style={{ flex: 1, minHeight: 0 }}>
         <Stack gap={2}>
@@ -105,6 +110,7 @@ const NearbySidebarContentDetail = ({ detailState }: { detailState: NearbySideba
 }
 
 const NearbySidebarContentList = ({ listState }: { listState: NearbySidebarListState }) => {
+  const { t } = useTranslation()
   const locale = useSelector(selectLocale)
 
   return (
@@ -127,7 +133,10 @@ const NearbySidebarContentList = ({ listState }: { listState: NearbySidebarListS
         value={listState.selectedStopId}
         onChange={listState.onSelectStop}
       >
-        {listState.nearbyStopGroups.map((stopGroup) => (
+        {listState.nearbyStopGroups.map((stopGroup) => {
+          const stopBearingLabel = getStopGroupBearingLabel(t, stopGroup)
+
+          return (
           <AccordionItem
             value={stopGroup.StationID}
             key={stopGroup.StationID}
@@ -140,9 +149,16 @@ const NearbySidebarContentList = ({ listState }: { listState: NearbySidebarListS
             }}
           >
             <AccordionControl>
-              <Text style={{ flex: '0 1 auto', minWidth: 0 }} lineClamp={1}>
-                {getLocalizedText(stopGroup.StopName, locale)}
-              </Text>
+              <Flex justify="space-between" align="center" gap="xs" w="100%">
+                <Text style={{ flex: '1 1 auto', minWidth: 0 }} lineClamp={1}>
+                  {getLocalizedText(stopGroup.StopName, locale)}
+                </Text>
+                {stopBearingLabel && (
+                  <Text size="sm" c="dimmed" mr="xs">
+                    {stopBearingLabel}
+                  </Text>
+                )}
+              </Flex>
             </AccordionControl>
             <AccordionPanel>
               <NearbyStopDetail
@@ -155,7 +171,8 @@ const NearbySidebarContentList = ({ listState }: { listState: NearbySidebarListS
               />
             </AccordionPanel>
           </AccordionItem>
-        ))}
+          )
+        })}
       </Accordion>
       )}
     </ScrollArea>

--- a/app/components/nearby/NearbyStopDetail.test.tsx
+++ b/app/components/nearby/NearbyStopDetail.test.tsx
@@ -2,6 +2,8 @@
 
 import { fireEvent, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import i18n from '~/modules/i18n'
+import { AppLocaleType } from '~/modules/enums/AppLocaleType'
 import { BearingType } from '~/modules/enums/BearingType'
 import { CityNameType } from '~/modules/enums/CityNameType'
 import { GeoPermissionType } from '~/modules/enums/geo/GeoPermissionType'
@@ -9,6 +11,8 @@ import geoSlice from '~/modules/slices/geoSlice'
 import { createTestStore } from '~/test/createTestStore'
 import { renderWithStore } from '~/test/render'
 import { NearbyStopDetail } from './NearbyStopDetail'
+
+const t = i18n.getFixedT(AppLocaleType.ZH_TW)
 
 const stopGroup = {
   StationID: 'station-1',
@@ -32,6 +36,8 @@ const stopGroup = {
     VersionID: 1
   }]
 }
+const stopNameZhTW = stopGroup.StopName['zh-TW']
+const navigateToStopLabel = t('components.routeStopList.navigateAriaLabel', { stopName: stopNameZhTW })
 
 function renderNearbyStopDetail(displayMode: 'content' | 'full' | 'title' = 'content') {
   return renderNearbyStopDetailWithStopGroup(stopGroup, displayMode)
@@ -75,8 +81,8 @@ describe('NearbyStopDetail', () => {
   it('renders only the stop name in title mode', () => {
     renderNearbyStopDetail('title')
 
-    expect(screen.getByText('市政府')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /導航至\s*市政府/ })).not.toBeInTheDocument()
+    expect(screen.getByText(stopNameZhTW)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: navigateToStopLabel })).not.toBeInTheDocument()
   })
 
   it('renders stop name with bearing label in title mode when bearing is available', () => {
@@ -96,8 +102,14 @@ describe('NearbyStopDetail', () => {
       ]
     }, 'title')
 
-    expect(screen.getByText('市政府')).toBeInTheDocument()
-    expect(screen.getByText('往北 / 往南')).toBeInTheDocument()
+    expect(screen.getByText(stopNameZhTW)).toBeInTheDocument()
+    const northBearingLabel = t('common.bearing.north')
+    const southBearingLabel = t('common.bearing.south')
+    const bearingText = screen.getByText((content) =>
+      content === `${southBearingLabel} / ${northBearingLabel}` ||
+      content === `${northBearingLabel} / ${southBearingLabel}`
+    )
+    expect(bearingText).toBeInTheDocument()
   })
 
   it('renders stop distance when user coordinates are available', () => {
@@ -112,7 +124,7 @@ describe('NearbyStopDetail', () => {
   it('opens Google Maps directions from the navigation button', () => {
     renderNearbyStopDetail('full')
 
-    fireEvent.click(screen.getByRole('button', { name: /導航至\s*市政府/ }))
+    fireEvent.click(screen.getByRole('button', { name: navigateToStopLabel }))
 
     expect(window.open).toHaveBeenCalledWith(
       'https://www.google.com/maps/dir/?api=1&destination=25.033%2C121.5654',

--- a/app/components/nearby/NearbyStopDetail.test.tsx
+++ b/app/components/nearby/NearbyStopDetail.test.tsx
@@ -2,6 +2,7 @@
 
 import { fireEvent, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BearingType } from '~/modules/enums/BearingType'
 import { CityNameType } from '~/modules/enums/CityNameType'
 import { GeoPermissionType } from '~/modules/enums/geo/GeoPermissionType'
 import geoSlice from '~/modules/slices/geoSlice'
@@ -24,7 +25,7 @@ const stopGroup = {
     GeoHash: null,
     StopName: { 'zh-TW': '市政府', en: 'City Hall' },
     StopAddress: 'Address 1',
-    Bearing: null,
+    Bearing: null as BearingType | null,
     StopDescription: null,
     City: CityNameType.TAIPEI,
     UpdateTime: '2026-04-12T10:00:00+08:00',
@@ -33,6 +34,13 @@ const stopGroup = {
 }
 
 function renderNearbyStopDetail(displayMode: 'content' | 'full' | 'title' = 'content') {
+  return renderNearbyStopDetailWithStopGroup(stopGroup, displayMode)
+}
+
+function renderNearbyStopDetailWithStopGroup(
+  targetStopGroup: typeof stopGroup,
+  displayMode: 'content' | 'full' | 'title' = 'content'
+) {
   const store = createTestStore({
     reducer: {
       geolocation: geoSlice.reducer
@@ -49,7 +57,7 @@ function renderNearbyStopDetail(displayMode: 'content' | 'full' | 'title' = 'con
 
   return renderWithStore(
     <NearbyStopDetail
-      stopGroup={stopGroup}
+      stopGroup={targetStopGroup}
       routes={[]}
       onViewRoutes={vi.fn()}
       displayMode={displayMode}
@@ -69,6 +77,27 @@ describe('NearbyStopDetail', () => {
 
     expect(screen.getByText('市政府')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /導航至\s*市政府/ })).not.toBeInTheDocument()
+  })
+
+  it('renders stop name with bearing label in title mode when bearing is available', () => {
+    renderNearbyStopDetailWithStopGroup({
+      ...stopGroup,
+      stops: [
+        {
+          ...stopGroup.stops[0],
+          Bearing: BearingType.NORTH
+        },
+        {
+          ...stopGroup.stops[0],
+          StopUID: 'stop-2',
+          StopID: 'stop-2',
+          Bearing: BearingType.SOUTH
+        }
+      ]
+    }, 'title')
+
+    expect(screen.getByText('市政府')).toBeInTheDocument()
+    expect(screen.getByText('往北 / 往南')).toBeInTheDocument()
   })
 
   it('renders stop distance when user coordinates are available', () => {

--- a/app/components/nearby/NearbyStopDetail.tsx
+++ b/app/components/nearby/NearbyStopDetail.tsx
@@ -44,9 +44,11 @@ export const NearbyStopDetail = ({
         <Text style={{ flex: 1, minWidth: 0 }} lineClamp={1}>
           {stopName}
         </Text>
-        <Text size="sm" c="dimmed" mr="xs">
-          {bearingLabel}
-        </Text>
+        {Boolean(bearingLabel) && (
+          <Text size="sm" c="dimmed" mr="xs">
+            {bearingLabel}
+          </Text>
+        )}
       </Flex>
     )
   }

--- a/app/components/nearby/NearbyStopDetail.tsx
+++ b/app/components/nearby/NearbyStopDetail.tsx
@@ -134,9 +134,11 @@ export const NearbyStopDetail = ({
             <Text style={{ flex: 1, minWidth: 0 }} lineClamp={1}>
               {stopName}
             </Text>
-            <Text size="sm" c="dimmed" mr="xs">
-              {bearingLabel}
-            </Text>
+            {Boolean(bearingLabel) && (
+              <Text size="sm" c="dimmed" mr="xs">
+                {bearingLabel}
+              </Text>
+            )}
           </Flex>
         </Stack>
       )}

--- a/app/components/nearby/NearbyStopDetail.tsx
+++ b/app/components/nearby/NearbyStopDetail.tsx
@@ -11,6 +11,7 @@ import { selectLocale } from '~/modules/slices/localeSlice'
 import { toLatLng } from '~/modules/utils/geo/convertCoordinates'
 import { getCityTranslationKey } from '~/modules/utils/i18n/getCityTranslationKey'
 import { getLocalizedText } from '~/modules/utils/i18n/getLocalizedText'
+import { getStopGroupBearingLabel } from '~/modules/utils/nearby/getStopGroupBearingLabel'
 
 interface PropType {
   stopGroup: NearbyStopGroup
@@ -35,12 +36,18 @@ export const NearbyStopDetail = ({
   const locale = useSelector(selectLocale)
   const stopName = getLocalizedText(stopGroup.StopName, locale)
   const destination = toLatLng(stopGroup.position)!
+  const bearingLabel = getStopGroupBearingLabel(t, stopGroup)
 
   if (displayMode === 'title') {
     return (
-      <Text style={{ flex: 1, minWidth: 0 }} lineClamp={1}>
-        {stopName}
-      </Text>
+      <Flex gap="xs" align="center" wrap="nowrap">
+        <Text style={{ flex: 1, minWidth: 0 }} lineClamp={1}>
+          {stopName}
+        </Text>
+        <Text size="sm" c="dimmed" mr="xs">
+          {bearingLabel}
+        </Text>
+      </Flex>
     )
   }
 
@@ -113,6 +120,7 @@ export const NearbyStopDetail = ({
       {displayMode === 'full' && (
         <Stack
           gap={4}
+          pb="xs"
           style={{
             position: 'sticky',
             top: 0,
@@ -120,9 +128,14 @@ export const NearbyStopDetail = ({
             backgroundColor: 'var(--mantine-color-body)'
           }}
         >
-          <Text style={{ flex: 1, minWidth: 0 }} lineClamp={1}>
-            {stopName}
-          </Text>
+          <Flex gap="xs" align="center" wrap="nowrap">
+            <Text style={{ flex: 1, minWidth: 0 }} lineClamp={1}>
+              {stopName}
+            </Text>
+            <Text size="sm" c="dimmed" mr="xs">
+              {bearingLabel}
+            </Text>
+          </Flex>
         </Stack>
       )}
       {detailSections.map((section) => (

--- a/app/modules/apis/bus.ts
+++ b/app/modules/apis/bus.ts
@@ -12,7 +12,7 @@ import { getBusErrorModal } from './errors/busError'
 import { openGlobalModal } from '../slices/globalModalSlice'
 import { areaMapCity } from '../consts/area'
 import type { LatLng } from '../types/CoordsType'
-import { buildNearbyStopOfRouteQuery, buildNearbyStopQuery } from '../utils/geo/buildNearbyStopQuery'
+import { buildNearbyStopOfRouteQuery, buildNearbyStopQuery, buildStopsByCityAndIdsQuery } from '../utils/api/tdxQuery'
 import {
   transformBusRoute,
   transformEstimatedArrival,
@@ -36,6 +36,7 @@ const baseQuery = fetchBaseQuery({
 const DEFAULT_RETENTION_SECONDS = 60 * 5
 const AREA_ROUTES_RETENTION_SECONDS = 60 * 15
 const NEARBY_STOP_OF_ROUTE_BATCH_SIZE = 40
+const STOPS_BY_IDS_BATCH_SIZE = 40
 
 export const busApi = createApi({
   reducerPath: 'busApi',
@@ -143,6 +144,44 @@ export const busApi = createApi({
       query: (cityName) => `/Stop/City/${cityName}?%24format=JSON`,
       transformResponse: (res: TdxStop[]) => transformStops(res)
     }),
+    getStopsByCityAndIds: build.query<Stop[], { city: CityNameType, stopIds: string[] }>({
+      queryFn: async ({ city, stopIds }, _api, _extraOptions, baseQuery) => {
+        if (stopIds.length === 0) {
+          return { data: [] }
+        }
+
+        const dedupedStopIds = Array.from(new Set(stopIds))
+        const stopIdBatches = Array.from(
+          { length: Math.ceil(dedupedStopIds.length / STOPS_BY_IDS_BATCH_SIZE) },
+          (_, index) => dedupedStopIds.slice(
+            index * STOPS_BY_IDS_BATCH_SIZE,
+            (index + 1) * STOPS_BY_IDS_BATCH_SIZE
+          )
+        )
+
+        const batchResults = await Promise.all(
+          stopIdBatches.map((stopIdBatch) =>
+            baseQuery(buildStopsByCityAndIdsQuery(city, stopIdBatch))
+          )
+        )
+
+        const errorResult = batchResults.find((result) => result.error != null)
+        if (errorResult?.error != null) {
+          return { error: errorResult.error }
+        }
+
+        const transformedStops = batchResults.flatMap((result) =>
+          transformStops(result.data as TdxStop[])
+        )
+
+        const dedupedStopsById = transformedStops.reduce<Map<string, Stop>>((result, stop) => {
+          result.set(stop.StopUID, stop)
+          return result
+        }, new Map())
+
+        return { data: Array.from(dedupedStopsById.values()) }
+      }
+    }),
     getStopsByArea: build.query<Stop[], AreaType>({
       queryFn: async (area, _api, _extraOptions, baseQuery) => {
         const cityResults = await Promise.all(
@@ -204,6 +243,7 @@ export const {
   useGetRealtimeByFrequencyByRouteQuery,
   useGetRealtimeNearStopsByRouteQuery,
   useGetRouteShapesByRouteQuery,
+  useGetStopsByCityAndIdsQuery,
   useGetRoutesByCityQuery,
   useGetStopOfRoutesByCityQuery,
   useGetStopsByCityQuery,

--- a/app/modules/apis/bus.ts
+++ b/app/modules/apis/bus.ts
@@ -13,6 +13,7 @@ import { openGlobalModal } from '../slices/globalModalSlice'
 import { areaMapCity } from '../consts/area'
 import type { LatLng } from '../types/CoordsType'
 import { buildNearbyStopOfRouteQuery, buildNearbyStopQuery, buildStopsByCityAndIdsQuery } from '../utils/api/tdxQuery'
+import { queryArrayWith414Fallback } from '../utils/api/queryWith414Fallback'
 import {
   transformBusRoute,
   transformEstimatedArrival,
@@ -35,8 +36,6 @@ const baseQuery = fetchBaseQuery({
 
 const DEFAULT_RETENTION_SECONDS = 60 * 5
 const AREA_ROUTES_RETENTION_SECONDS = 60 * 15
-const NEARBY_STOP_OF_ROUTE_BATCH_SIZE = 40
-const STOPS_BY_IDS_BATCH_SIZE = 40
 
 export const busApi = createApi({
   reducerPath: 'busApi',
@@ -70,37 +69,29 @@ export const busApi = createApi({
     }),
     getStopOfRoutesByArea: build.query<StopOfRoute[], { area: AreaType, stopUIDs?: string[] }>({
       queryFn: async ({ area, stopUIDs = [] }, _api, _extraOptions, baseQuery) => {
-        const stopUIDBatches = stopUIDs.length > 0
-          ? Array.from(
-            { length: Math.ceil(stopUIDs.length / NEARBY_STOP_OF_ROUTE_BATCH_SIZE) },
-            (_, index) => stopUIDs.slice(
-              index * NEARBY_STOP_OF_ROUTE_BATCH_SIZE,
-              (index + 1) * NEARBY_STOP_OF_ROUTE_BATCH_SIZE
-            )
-              )
-          : [[]]
+        const cityResults = await Promise.all(
+          areaMapCity[area].map(async (city) => ({
+            city,
+            result: await queryArrayWith414Fallback({
+              items: stopUIDs,
+              queryBatch: async (stopUIDBatch) => {
+                const batchResult = await baseQuery(buildNearbyStopOfRouteQuery(city, stopUIDBatch))
 
-        const batchResults: Array<{
-          city: CityNameType
-          result: Awaited<ReturnType<typeof baseQuery>>
-        }> = []
+                return {
+                  data: (batchResult.data as TdxStopOfRoute[]) ?? [],
+                  error: batchResult.error
+                }
+              }
+            })
+          }))
+        )
 
-        for (const batch of stopUIDBatches) {
-          const cityResults = await Promise.all(
-            areaMapCity[area].map(async (city) => ({
-              city,
-              result: await baseQuery(buildNearbyStopOfRouteQuery(city, batch))
-            }))
-          )
-
-          const errorResult = cityResults.find(({ result }) => result.error != null)
-          if (errorResult?.result.error != null) {
-            return { error: errorResult.result.error }
-          }
-          batchResults.push(...cityResults)
+        const errorResult = cityResults.find(({ result }) => result.error != null)
+        if (errorResult?.result.error != null) {
+          return { error: errorResult.result.error }
         }
 
-        const transformedStopOfRoutes = batchResults.flatMap(({ city, result }) =>
+        const transformedStopOfRoutes = cityResults.flatMap(({ city, result }) =>
           (result.data as TdxStopOfRoute[]).map((stopOfRoute) => transformStopOfRoute(stopOfRoute, city))
         )
 
@@ -150,29 +141,24 @@ export const busApi = createApi({
           return { data: [] }
         }
 
-        const dedupedStopIds = Array.from(new Set(stopIds))
-        const stopIdBatches = Array.from(
-          { length: Math.ceil(dedupedStopIds.length / STOPS_BY_IDS_BATCH_SIZE) },
-          (_, index) => dedupedStopIds.slice(
-            index * STOPS_BY_IDS_BATCH_SIZE,
-            (index + 1) * STOPS_BY_IDS_BATCH_SIZE
-          )
-        )
+        const deduplicatedStopIds = Array.from(new Set(stopIds))
+        const queryResult = await queryArrayWith414Fallback({
+          items: deduplicatedStopIds,
+          queryBatch: async (stopIdBatch) => {
+            const batchResult = await baseQuery(buildStopsByCityAndIdsQuery(city, stopIdBatch))
 
-        const batchResults = await Promise.all(
-          stopIdBatches.map((stopIdBatch) =>
-            baseQuery(buildStopsByCityAndIdsQuery(city, stopIdBatch))
-          )
-        )
+            return {
+              data: (batchResult.data as TdxStop[]) ?? [],
+              error: batchResult.error
+            }
+          }
+        })
 
-        const errorResult = batchResults.find((result) => result.error != null)
-        if (errorResult?.error != null) {
-          return { error: errorResult.error }
+        if (queryResult.error) {
+          return { error: queryResult.error }
         }
 
-        const transformedStops = batchResults.flatMap((result) =>
-          transformStops(result.data as TdxStop[])
-        )
+        const transformedStops = transformStops(queryResult.data ?? [])
 
         const dedupedStopsById = transformedStops.reduce<Map<string, Stop>>((result, stop) => {
           result.set(stop.StopUID, stop)

--- a/app/modules/apis/errors/busError.test.ts
+++ b/app/modules/apis/errors/busError.test.ts
@@ -98,6 +98,17 @@ describe('getBusErrorModal', () => {
     ).toBeNull()
   })
 
+  it('does not open a modal when a 414 is wrapped as a parsing error', () => {
+    expect(
+      getBusErrorModal({
+        status: 'PARSING_ERROR',
+        originalStatus: 414,
+        data: 'URI Too Long',
+        error: 'SyntaxError: Unexpected token U in JSON at position 0'
+      })
+    ).toBeNull()
+  })
+
   it('returns the system modal for 5xx errors', () => {
     expect(
       getBusErrorModal({

--- a/app/modules/apis/errors/busError.ts
+++ b/app/modules/apis/errors/busError.ts
@@ -5,6 +5,7 @@ import type { OpenGlobalModalPayload } from '../../slices/globalModalSlice'
 
 export enum TdxHttpErrorStatus {
   UNAUTHORIZED = 401,
+  URI_TOO_LONG = 414,
   RATE_LIMIT = 429
 }
 
@@ -77,6 +78,10 @@ export const getBusErrorModal = (error: FetchBaseQueryError) => {
   }
 
   if (tdxHttpStatus === TdxHttpErrorStatus.RATE_LIMIT) {
+    return null
+  }
+
+  if (tdxHttpStatus === TdxHttpErrorStatus.URI_TOO_LONG) {
     return null
   }
 

--- a/app/modules/consts/bearing.ts
+++ b/app/modules/consts/bearing.ts
@@ -1,0 +1,15 @@
+import { BearingType } from '../enums/BearingType'
+
+type ZhTWLocale = typeof import('../i18n/locales/zh-TW').zhTW
+type BearingTranslationKey = `common.bearing.${keyof ZhTWLocale['translation']['common']['bearing']}`
+
+export const bearingTranslationKeyMap: Record<BearingType, BearingTranslationKey> = {
+  [BearingType.EAST]: 'common.bearing.east',
+  [BearingType.WEST]: 'common.bearing.west',
+  [BearingType.SOUTH]: 'common.bearing.south',
+  [BearingType.NORTH]: 'common.bearing.north',
+  [BearingType.SOUTHEAST]: 'common.bearing.southeast',
+  [BearingType.NORTHEAST]: 'common.bearing.northeast',
+  [BearingType.SOUTHWEST]: 'common.bearing.southwest',
+  [BearingType.NORTHWEST]: 'common.bearing.northwest'
+}

--- a/app/modules/hooks/useRouteBaseData.ts
+++ b/app/modules/hooks/useRouteBaseData.ts
@@ -67,6 +67,10 @@ export function useRouteBaseData(
     )
   const { data: stopsByCity = [], isLoading: isStopsLoading, error: stopsError } =
     busApi.useGetStopsByCityQuery(routeQueryCity, { skip: !options })
+  const { data: routeShapes = [] } = busApi.useGetRouteShapesByRouteQuery(
+    { city: routeQueryCity, routeUID: id ?? '' },
+    { skip: !options || !id }
+  )
 
   const targetFavoriteRouteStop = useMemo(() => {
     if (!options) return null
@@ -125,7 +129,7 @@ export function useRouteBaseData(
     ) ?? null
   }, [activeTab, id, routeTabs, stopOfRoutes])
 
-  const activeSubRoute = useMemo<BusSubRoute<Date | null> | null>(() => {
+  const subRoute = useMemo<BusSubRoute<Date | null> | null>(() => {
     if (!busRoute || !activeTab) return null
 
     const activeRouteTab = routeTabs.find((tab) => tab.id === activeTab)
@@ -148,26 +152,26 @@ export function useRouteBaseData(
   }, [stopsByCity])
 
   const baseStops = useMemo<RouteBaseStop[]>(() => {
-    if (!activeStopOfRoute || !activeSubRoute || !busRoute) return []
+    if (!activeStopOfRoute || !subRoute || !busRoute) return []
 
     return activeStopOfRoute.Stops.map((stop) => {
       const stationKey = stop.StationID ?? stop.StopUID
       const favoriteRouteStop: FavoriteRouteStop = {
-        favoriteId: `${busRoute.RouteUID}-${activeSubRoute.SubRouteUID}-${activeSubRoute.Direction}-${stationKey}`,
+        favoriteId: `${busRoute.RouteUID}-${subRoute.SubRouteUID}-${subRoute.Direction}-${stationKey}`,
         city: busRoute.City,
         routeUID: busRoute.RouteUID,
         routeName: busRoute.RouteName,
-        subRouteUID: activeSubRoute.SubRouteUID,
-        subRouteName: activeSubRoute.SubRouteName,
-        direction: activeSubRoute.Direction,
+        subRouteUID: subRoute.SubRouteUID,
+        subRouteName: subRoute.SubRouteName,
+        direction: subRoute.Direction,
         stopUID: stop.StopUID,
         stopID: stop.StopID,
         stationID: stop.StationID ?? null,
         stationKey,
         stopName: stop.StopName,
         stopSequence: stop.StopSequence,
-        departure: activeSubRoute.DepartureStopName ?? busRoute.DepartureStopName,
-        destination: activeSubRoute.DestinationStopName ?? busRoute.DestinationStopName
+        departure: subRoute.DepartureStopName ?? busRoute.DepartureStopName,
+        destination: subRoute.DestinationStopName ?? busRoute.DestinationStopName
       }
 
       return {
@@ -180,7 +184,7 @@ export function useRouteBaseData(
         isFavorite: isFavoriteRouteStop(favoriteRouteStop.favoriteId)
       }
     })
-  }, [activeStopOfRoute, activeSubRoute, busRoute, isFavoriteRouteStop, locale])
+  }, [activeStopOfRoute, subRoute, busRoute, isFavoriteRouteStop, locale])
 
   const routeMapStops = useMemo(() => {
     return (activeStopOfRoute?.Stops ?? []).map((stop: StopOfRouteStop) => ({
@@ -191,12 +195,21 @@ export function useRouteBaseData(
     }))
   }, [activeStopOfRoute, locale, stopPositionMap])
 
+  const routePath = useMemo(() => {
+    if (!subRoute) return []
+
+    return routeShapes.find((routeShape) =>
+      routeShape.SubRouteUID === subRoute.SubRouteUID &&
+      routeShape.Direction === subRoute.Direction
+    )?.path ?? []
+  }, [subRoute, routeShapes])
+
   const highlightedStopId = useMemo(() => {
-    if (!targetFavoriteRouteStop || !activeSubRoute || !activeStopOfRoute || !busRoute) return null
+    if (!targetFavoriteRouteStop || !subRoute || !activeStopOfRoute || !busRoute) return null
     if (
       targetFavoriteRouteStop.routeUID !== busRoute.RouteUID ||
-      targetFavoriteRouteStop.subRouteUID !== activeSubRoute.SubRouteUID ||
-      targetFavoriteRouteStop.direction !== activeSubRoute.Direction
+      targetFavoriteRouteStop.subRouteUID !== subRoute.SubRouteUID ||
+      targetFavoriteRouteStop.direction !== subRoute.Direction
     ) {
       return null
     }
@@ -210,7 +223,7 @@ export function useRouteBaseData(
     })
 
     return matchedStop?.StopUID ?? null
-  }, [activeStopOfRoute, activeSubRoute, busRoute, targetFavoriteRouteStop])
+  }, [activeStopOfRoute, subRoute, busRoute, targetFavoriteRouteStop])
 
   const isLoading = isRoutesLoading || isStopOfRoutesLoading || isStopsLoading
   const isStopListLoading = Boolean(busRoute) && routeTabs.length > 0 && (isStopOfRoutesLoading || isStopsLoading)
@@ -224,7 +237,8 @@ export function useRouteBaseData(
   }, [busRoute, error, routeTabs.length, t])
 
   return {
-    activeSubRoute,
+    subRoute,
+    routePath,
     baseStops,
     busRoute,
     highlightedStopId,

--- a/app/modules/hooks/useRouteBaseData.ts
+++ b/app/modules/hooks/useRouteBaseData.ts
@@ -65,12 +65,22 @@ export function useRouteBaseData(
       { city: routeQueryCity, routeUID: id },
       { skip: !options }
     )
-  const { data: stopsByCity = [], isLoading: isStopsLoading, error: stopsError } =
-    busApi.useGetStopsByCityQuery(routeQueryCity, { skip: !options })
   const { data: routeShapes = [] } = busApi.useGetRouteShapesByRouteQuery(
     { city: routeQueryCity, routeUID: id ?? '' },
     { skip: !options || !id }
   )
+  const routeStopIds = useMemo(() => {
+    if (!id) return []
+
+    return stopOfRoutes
+      .filter((stopOfRoute) => stopOfRoute.RouteUID === id)
+      .flatMap((stopOfRoute) => stopOfRoute.Stops.flatMap((stop) => [stop.StopUID, stop.StopID]))
+  }, [id, stopOfRoutes])
+  const { data: routeStops = [], isLoading: isStopsLoading, error: stopsError } =
+    busApi.useGetStopsByCityAndIdsQuery(
+      { city: routeQueryCity, stopIds: routeStopIds },
+      { skip: !options || routeStopIds.length === 0 }
+    )
 
   const targetFavoriteRouteStop = useMemo(() => {
     if (!options) return null
@@ -142,14 +152,14 @@ export function useRouteBaseData(
   }, [activeTab, busRoute, routeTabs])
 
   const stopPositionMap = useMemo(() => {
-    return stopsByCity.reduce<Map<string, (typeof stopsByCity)[number]['position']>>((result, stop) => {
+    return routeStops.reduce<Map<string, (typeof routeStops)[number]['position']>>((result, stop) => {
       if (stop.position) {
         result.set(stop.StopUID, stop.position)
         result.set(stop.StopID, stop.position)
       }
       return result
     }, new Map())
-  }, [stopsByCity])
+  }, [routeStops])
 
   const baseStops = useMemo<RouteBaseStop[]>(() => {
     if (!activeStopOfRoute || !subRoute || !busRoute) return []

--- a/app/modules/hooks/useRouteBaseData.ts
+++ b/app/modules/hooks/useRouteBaseData.ts
@@ -127,9 +127,13 @@ export function useRouteBaseData(
     )?.id ?? routeTabs[0].id
   }, [routeTabs, targetFavoriteRouteStop])
 
-  const activeStopOfRoute = useMemo(() => {
+  const activeRouteTab = useMemo(() => {
     if (!activeTab) return null
-    const activeRouteTab = routeTabs.find((tab) => tab.id === activeTab)
+
+    return routeTabs.find((tab) => tab.id === activeTab) ?? null
+  }, [activeTab, routeTabs])
+
+  const activeStopOfRoute = useMemo(() => {
     if (!activeRouteTab) return null
 
     return stopOfRoutes.find((stopOfRoute) =>
@@ -137,19 +141,17 @@ export function useRouteBaseData(
       stopOfRoute.SubRouteUID === activeRouteTab.subRouteUID &&
       stopOfRoute.Direction === activeRouteTab.direction
     ) ?? null
-  }, [activeTab, id, routeTabs, stopOfRoutes])
+  }, [activeRouteTab, id, stopOfRoutes])
 
   const subRoute = useMemo<BusSubRoute<Date | null> | null>(() => {
-    if (!busRoute || !activeTab) return null
-
-    const activeRouteTab = routeTabs.find((tab) => tab.id === activeTab)
+    if (!busRoute) return null
     if (!activeRouteTab) return null
 
     return busRoute.SubRoutes.find((subRoute) =>
       subRoute.SubRouteUID === activeRouteTab.subRouteUID &&
       subRoute.Direction === activeRouteTab.direction
     ) ?? null
-  }, [activeTab, busRoute, routeTabs])
+  }, [activeRouteTab, busRoute])
 
   const stopPositionMap = useMemo(() => {
     return routeStops.reduce<Map<string, (typeof routeStops)[number]['position']>>((result, stop) => {

--- a/app/modules/hooks/useRouteBaseData.ts
+++ b/app/modules/hooks/useRouteBaseData.ts
@@ -72,9 +72,11 @@ export function useRouteBaseData(
   const routeStopIds = useMemo(() => {
     if (!id) return []
 
-    return stopOfRoutes
+    const stopIds = stopOfRoutes
       .filter((stopOfRoute) => stopOfRoute.RouteUID === id)
       .flatMap((stopOfRoute) => stopOfRoute.Stops.flatMap((stop) => [stop.StopUID, stop.StopID]))
+
+    return Array.from(new Set(stopIds)).sort()
   }, [id, stopOfRoutes])
   const { data: routeStops = [], isLoading: isStopsLoading, error: stopsError } =
     busApi.useGetStopsByCityAndIdsQuery(

--- a/app/modules/hooks/useRouteRealtimeData.test.ts
+++ b/app/modules/hooks/useRouteRealtimeData.test.ts
@@ -14,21 +14,18 @@ import { useRouteRealtimeData } from './useRouteRealtimeData'
 const {
   mockUseGetEstimatedArrivalByRouteQuery,
   mockUseGetRealtimeByFrequencyByRouteQuery,
-  mockUseGetRealtimeNearStopsByRouteQuery,
-  mockUseGetRouteShapesByRouteQuery
+  mockUseGetRealtimeNearStopsByRouteQuery
 } = vi.hoisted(() => ({
   mockUseGetEstimatedArrivalByRouteQuery: vi.fn(),
   mockUseGetRealtimeByFrequencyByRouteQuery: vi.fn(),
-  mockUseGetRealtimeNearStopsByRouteQuery: vi.fn(),
-  mockUseGetRouteShapesByRouteQuery: vi.fn()
+  mockUseGetRealtimeNearStopsByRouteQuery: vi.fn()
 }))
 
 vi.mock('~/modules/apis/bus', () => ({
   busApi: {
     useGetEstimatedArrivalByRouteQuery: mockUseGetEstimatedArrivalByRouteQuery,
     useGetRealtimeByFrequencyByRouteQuery: mockUseGetRealtimeByFrequencyByRouteQuery,
-    useGetRealtimeNearStopsByRouteQuery: mockUseGetRealtimeNearStopsByRouteQuery,
-    useGetRouteShapesByRouteQuery: mockUseGetRouteShapesByRouteQuery
+    useGetRealtimeNearStopsByRouteQuery: mockUseGetRealtimeNearStopsByRouteQuery
   }
 }))
 
@@ -53,7 +50,7 @@ const busRoute: BusRoute<Date | null> = {
   VersionID: 0
 }
 
-const activeSubRoute = {
+const subRoute = {
   SubRouteUID: 'subroute-1',
   SubRouteID: 'subroute-1',
   OperatorIDs: [],
@@ -78,14 +75,10 @@ describe('useRouteRealtimeData', () => {
     mockUseGetEstimatedArrivalByRouteQuery.mockReset()
     mockUseGetRealtimeByFrequencyByRouteQuery.mockReset()
     mockUseGetRealtimeNearStopsByRouteQuery.mockReset()
-    mockUseGetRouteShapesByRouteQuery.mockReset()
 
     mockUseGetRealtimeByFrequencyByRouteQuery.mockReturnValue({
       data: [],
       error: null
-    })
-    mockUseGetRouteShapesByRouteQuery.mockReturnValue({
-      data: []
     })
   })
 
@@ -127,7 +120,7 @@ describe('useRouteRealtimeData', () => {
     }))
 
     const { rerender } = renderHook(() => useRouteRealtimeData({
-      activeSubRoute,
+      subRoute,
       busRoute,
       city: CityNameType.TAIPEI,
       id: 'route-1'

--- a/app/modules/hooks/useRouteRealtimeData.ts
+++ b/app/modules/hooks/useRouteRealtimeData.ts
@@ -27,7 +27,7 @@ type RealtimeQueryState =
   | { status: RealtimeQueryStatus.READY }
 
 interface UseRouteRealtimeDataOptions {
-  activeSubRoute: BusSubRoute<Date | null>
+  subRoute: BusSubRoute<Date | null>
   busRoute: BusRoute<Date | null>
   city: CityNameType
   id: string
@@ -36,7 +36,7 @@ interface UseRouteRealtimeDataOptions {
 export function useRouteRealtimeData(options: UseRouteRealtimeDataOptions | null) {
   const { t } = useTranslation()
   const locale = useSelector(selectLocale)
-  const activeSubRoute = options?.activeSubRoute ?? null
+  const subRoute = options?.subRoute ?? null
   const busRoute = options?.busRoute ?? null
 
   // Keep RTK Query args well-typed; skip prevents requests until realtime options are ready.
@@ -58,7 +58,7 @@ export function useRouteRealtimeData(options: UseRouteRealtimeDataOptions | null
       status: RealtimeQueryStatus.WAITING,
       waitMs: REALTIME_INITIAL_DELAY_MS
     })
-  }, [activeSubRoute?.Direction, activeSubRoute?.SubRouteUID, busRoute?.RouteUID, options?.id, options?.city])
+  }, [subRoute?.Direction, subRoute?.SubRouteUID, busRoute?.RouteUID, options?.id, options?.city])
 
   useEffect(() => {
     if (realtimeQueryState.status !== RealtimeQueryStatus.WAITING) {
@@ -115,11 +115,6 @@ export function useRouteRealtimeData(options: UseRouteRealtimeDataOptions | null
       refetchOnReconnect: true
     }
   )
-  const { data: routeShapes = [] } = busApi.useGetRouteShapesByRouteQuery(
-    realtimeQueryArgs,
-    { skip: skipRealtime }
-  )
-
   const isRealtimeRateLimited = isTdxRateLimitError(estimatedArrivalsError) ||
     isTdxRateLimitError(realtimeNearStopsError)
 
@@ -141,18 +136,18 @@ export function useRouteRealtimeData(options: UseRouteRealtimeDataOptions | null
   }, [isRealtimeRateLimited])
 
   const directionMatchedEstimatedArrivals = useMemo(() => {
-    if (!activeSubRoute || !busRoute) return []
+    if (!subRoute || !busRoute) return []
 
     return estimatedArrivals.filter((estimatedArrival) =>
-      estimatedArrival.Direction === activeSubRoute.Direction
+      estimatedArrival.Direction === subRoute.Direction
     )
-  }, [activeSubRoute, busRoute, estimatedArrivals])
+  }, [subRoute, busRoute, estimatedArrivals])
 
   const activeEstimatedArrivals = useMemo(() => {
-    if (!activeSubRoute || !busRoute) return []
+    if (!subRoute || !busRoute) return []
 
     const subRouteMatchedEstimatedArrivals = directionMatchedEstimatedArrivals.filter((estimatedArrival) =>
-      estimatedArrival.SubRouteUID === activeSubRoute.SubRouteUID
+      estimatedArrival.SubRouteUID === subRoute.SubRouteUID
     )
 
     if (subRouteMatchedEstimatedArrivals.length > 0) {
@@ -167,17 +162,17 @@ export function useRouteRealtimeData(options: UseRouteRealtimeDataOptions | null
     return routeLevelEstimatedArrivals.length > 0
       ? routeLevelEstimatedArrivals
       : directionMatchedEstimatedArrivals
-  }, [activeSubRoute, busRoute, directionMatchedEstimatedArrivals])
+  }, [subRoute, busRoute, directionMatchedEstimatedArrivals])
 
   const activeRealtimeNearStops = useMemo(() => realtimeNearStops.filter((realtimeNearStop) =>
-    realtimeNearStop.SubRouteUID === activeSubRoute?.SubRouteUID &&
-    realtimeNearStop.Direction === activeSubRoute?.Direction
-  ), [activeSubRoute, realtimeNearStops])
+    realtimeNearStop.SubRouteUID === subRoute?.SubRouteUID &&
+    realtimeNearStop.Direction === subRoute?.Direction
+  ), [subRoute, realtimeNearStops])
   const activeRealtimeByFrequency = useMemo(() => realtimeByFrequency.filter((realtimeVehicle) =>
-    realtimeVehicle.SubRouteUID === activeSubRoute?.SubRouteUID &&
-    realtimeVehicle.Direction === activeSubRoute?.Direction &&
+    realtimeVehicle.SubRouteUID === subRoute?.SubRouteUID &&
+    realtimeVehicle.Direction === subRoute?.Direction &&
     realtimeVehicle.position != null
-  ) as Array<(typeof realtimeByFrequency)[number] & { position: NonNullable<(typeof realtimeByFrequency)[number]['position']> }>, [activeSubRoute, realtimeByFrequency])
+  ) as Array<(typeof realtimeByFrequency)[number] & { position: NonNullable<(typeof realtimeByFrequency)[number]['position']> }>, [subRoute, realtimeByFrequency])
 
   const realtimeBusStatuses = useMemo(() => getRouteRealtimeBusStatuses(
     t,
@@ -292,17 +287,7 @@ export function useRouteRealtimeData(options: UseRouteRealtimeDataOptions | null
     realtimeBusStatuses.length
   ])
 
-  const activeRoutePath = useMemo(() => {
-    if (!activeSubRoute) return []
-
-    return routeShapes.find((routeShape) =>
-      routeShape.SubRouteUID === activeSubRoute.SubRouteUID &&
-      routeShape.Direction === activeSubRoute.Direction
-    )?.path ?? []
-  }, [activeSubRoute, routeShapes])
-
   return {
-    activeRoutePath,
     estimatedArrivalLabelsByStopKey,
     hasRealtimeError,
     isRealtimeLoading: isEstimatedArrivalsLoading || isRealtimeNearStopsLoading,

--- a/app/modules/hooks/useRouteSelectionState.ts
+++ b/app/modules/hooks/useRouteSelectionState.ts
@@ -1,0 +1,104 @@
+import { useDisclosure } from '@mantine/hooks'
+import { useCallback, useEffect, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import type { RouteTab } from './useRouteBaseData'
+
+interface RouteSelectionStop {
+  id: string
+  realtimeBuses: Array<{ id: string }>
+}
+
+interface UseRouteSelectionStateOptions {
+  defaultActiveTabId: string | null
+  isSm: boolean
+  routeTabs: RouteTab[]
+  setActiveTab: Dispatch<SetStateAction<string | null>>
+  stops: RouteSelectionStop[]
+}
+
+export function useRouteSelectionState(options: UseRouteSelectionStateOptions) {
+  const { defaultActiveTabId, isSm, routeTabs, setActiveTab, stops } = options
+  const [isSidebarOpened, { open: openSidebar, close: closeSidebar }] = useDisclosure(false)
+  const [listScrollBehavior, setListScrollBehavior] = useState<ScrollLogicalPosition>('nearest')
+  const [selectedStopId, setSelectedStopId] = useState<string | null>(null)
+  const [selectedVehicleId, setSelectedVehicleId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isSm) {
+      openSidebar()
+      return
+    }
+  }, [isSm, openSidebar])
+
+  useEffect(() => {
+    if (!routeTabs.length) {
+      setActiveTab(null)
+      return
+    }
+
+    setActiveTab((currentTab) => {
+      if (currentTab && routeTabs.some((tab) => tab.id === currentTab)) {
+        return currentTab
+      }
+      return defaultActiveTabId
+    })
+  }, [defaultActiveTabId, routeTabs, setActiveTab])
+
+  useEffect(() => {
+    if (!selectedStopId) return
+    if (stops.some((stop) => stop.id === selectedStopId)) return
+
+    setSelectedStopId(null)
+  }, [selectedStopId, stops])
+
+  useEffect(() => {
+    if (!selectedVehicleId) return
+    if (stops.some((stop) => stop.realtimeBuses.some((bus) => bus.id === selectedVehicleId))) return
+
+    setSelectedVehicleId(null)
+  }, [selectedVehicleId, stops])
+
+  const handleSelectStopFromList = useCallback((stopId: string) => {
+    setListScrollBehavior('nearest')
+    setSelectedStopId(stopId)
+    setSelectedVehicleId(null)
+
+    if (isSm) {
+      closeSidebar()
+    }
+  }, [closeSidebar, isSm])
+
+  const handleSelectVehicleFromList = useCallback((vehicleId: string) => {
+    setSelectedVehicleId(vehicleId)
+    setSelectedStopId(null)
+
+    if (isSm) {
+      closeSidebar()
+    }
+  }, [closeSidebar, isSm])
+
+  const handleSelectVehicleFromMap = useCallback((vehicleId: string) => {
+    setListScrollBehavior('start')
+    setSelectedVehicleId(vehicleId)
+    setSelectedStopId(null)
+  }, [])
+
+  const handleSelectStopFromMap = useCallback((stopId: string | null) => {
+    setListScrollBehavior('start')
+    setSelectedStopId(stopId)
+    setSelectedVehicleId(null)
+  }, [])
+
+  return {
+    closeSidebar,
+    handleSelectStopFromList,
+    handleSelectStopFromMap,
+    handleSelectVehicleFromList,
+    handleSelectVehicleFromMap,
+    isSidebarOpened,
+    listScrollBehavior,
+    openSidebar,
+    selectedStopId,
+    selectedVehicleId
+  }
+}

--- a/app/modules/i18n/locales/en.ts
+++ b/app/modules/i18n/locales/en.ts
@@ -61,6 +61,16 @@ export const en = {
         loop: 'Loop',
         shuttle: 'Shuttle',
         unknown: 'Unknown'
+      },
+      bearing: {
+        east: 'Eastbound',
+        west: 'Westbound',
+        south: 'Southbound',
+        north: 'Northbound',
+        southeast: 'Southeastbound',
+        northeast: 'Northeastbound',
+        southwest: 'Southwestbound',
+        northwest: 'Northwestbound'
       }
     },
     layout: {

--- a/app/modules/i18n/locales/zh-TW.ts
+++ b/app/modules/i18n/locales/zh-TW.ts
@@ -61,6 +61,16 @@ export const zhTW = {
         loop: '迴圈',
         shuttle: '循環',
         unknown: '未知'
+      },
+      bearing: {
+        east: '往東',
+        west: '往西',
+        south: '往南',
+        north: '往北',
+        southeast: '往東南',
+        northeast: '往東北',
+        southwest: '往西南',
+        northwest: '往西北'
       }
     },
     layout: {

--- a/app/modules/utils/api/queryWith414Fallback.test.ts
+++ b/app/modules/utils/api/queryWith414Fallback.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { queryArrayWith414Fallback } from './queryWith414Fallback'
+
+describe('queryArrayWith414Fallback', () => {
+  it('returns data directly when the first request succeeds', async () => {
+    const queryBatch = vi.fn(async (batchItems: number[]) => ({
+      data: batchItems
+    }))
+
+    const result = await queryArrayWith414Fallback({
+      items: [1, 2, 3],
+      queryBatch
+    })
+
+    expect(result).toEqual({ data: [1, 2, 3] })
+    expect(queryBatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('splits recursively for 414 and merges successful branches', async () => {
+    const queryBatch = vi.fn(async (batchItems: number[]) => {
+      if (batchItems.length > 2) {
+        return { error: { status: 414 as const } }
+      }
+
+      if (batchItems[0] === 3 && batchItems[1] === 4) {
+        return { error: { status: 414 as const } }
+      }
+
+      return { data: batchItems }
+    })
+
+    const result = await queryArrayWith414Fallback({
+      items: [1, 2, 3, 4],
+      queryBatch
+    })
+
+    expect(result).toEqual({ data: [1, 2, 3, 4] })
+  })
+
+  it('does not split when error is not a URI-too-long error', async () => {
+    const queryBatch = vi.fn(async () => ({
+      error: { status: 500 as const }
+    }))
+
+    const result = await queryArrayWith414Fallback({
+      items: [1, 2, 3],
+      queryBatch
+    })
+
+    expect(result).toEqual({ error: { status: 500 } })
+    expect(queryBatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns error when one-item batch still fails with 414', async () => {
+    const queryBatch = vi.fn(async () => ({
+      error: { status: 414 as const }
+    }))
+
+    const result = await queryArrayWith414Fallback({
+      items: [1],
+      queryBatch
+    })
+
+    expect(result).toEqual({ error: { status: 414 } })
+    expect(queryBatch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/modules/utils/api/queryWith414Fallback.test.ts
+++ b/app/modules/utils/api/queryWith414Fallback.test.ts
@@ -37,6 +37,30 @@ describe('queryArrayWith414Fallback', () => {
     expect(result).toEqual({ data: [1, 2, 3, 4] })
   })
 
+  it('splits recursively when 414 is wrapped as a parsing error', async () => {
+    const queryBatch = vi.fn(async (batchItems: number[]) => {
+      if (batchItems.length > 2) {
+        return {
+          error: {
+            status: 'PARSING_ERROR' as const,
+            originalStatus: 414 as const,
+            data: 'URI Too Long',
+            error: 'SyntaxError'
+          }
+        }
+      }
+
+      return { data: batchItems }
+    })
+
+    const result = await queryArrayWith414Fallback({
+      items: [1, 2, 3, 4],
+      queryBatch
+    })
+
+    expect(result).toEqual({ data: [1, 2, 3, 4] })
+  })
+
   it('does not split when error is not a URI-too-long error', async () => {
     const queryBatch = vi.fn(async () => ({
       error: { status: 500 as const }

--- a/app/modules/utils/api/queryWith414Fallback.ts
+++ b/app/modules/utils/api/queryWith414Fallback.ts
@@ -1,5 +1,6 @@
 interface QueryErrorLike {
   status?: unknown
+  originalStatus?: unknown
 }
 
 interface QueryResultLike<TData, TError extends QueryErrorLike> {
@@ -17,8 +18,12 @@ function isUriTooLongStatus(status: unknown): boolean {
   return status === 414
 }
 
+function isParsingErrorWithUriTooLongStatus(error: QueryErrorLike): boolean {
+  return error.status === 'PARSING_ERROR' && error.originalStatus === 414
+}
+
 function defaultShouldFallback<TError extends QueryErrorLike>(error: TError): boolean {
-  return isUriTooLongStatus(error.status)
+  return isUriTooLongStatus(error.status) || isParsingErrorWithUriTooLongStatus(error)
 }
 
 export async function queryArrayWith414Fallback<TItem, TData, TError extends QueryErrorLike>(

--- a/app/modules/utils/api/queryWith414Fallback.ts
+++ b/app/modules/utils/api/queryWith414Fallback.ts
@@ -1,0 +1,65 @@
+interface QueryErrorLike {
+  status?: unknown
+}
+
+interface QueryResultLike<TData, TError extends QueryErrorLike> {
+  data?: TData
+  error?: TError
+}
+
+interface QueryArrayWith414FallbackOptions<TItem, TData, TError extends QueryErrorLike> {
+  items: TItem[]
+  queryBatch: (batchItems: TItem[]) => Promise<QueryResultLike<TData[], TError>>
+  shouldFallback?: (error: TError) => boolean
+}
+
+function isUriTooLongStatus(status: unknown): boolean {
+  return status === 414
+}
+
+function defaultShouldFallback<TError extends QueryErrorLike>(error: TError): boolean {
+  return isUriTooLongStatus(error.status)
+}
+
+export async function queryArrayWith414Fallback<TItem, TData, TError extends QueryErrorLike>(
+  options: QueryArrayWith414FallbackOptions<TItem, TData, TError>
+): Promise<QueryResultLike<TData[], TError>> {
+  const { items, queryBatch, shouldFallback = defaultShouldFallback } = options
+  const result = await queryBatch(items)
+
+  if (!result.error) {
+    return {
+      data: result.data ?? []
+    }
+  }
+
+  if (!shouldFallback(result.error) || items.length <= 1) {
+    return { error: result.error }
+  }
+
+  const middle = Math.floor(items.length / 2)
+  const leftItems = items.slice(0, middle)
+  const rightItems = items.slice(middle)
+
+  const leftResult = await queryArrayWith414Fallback({
+    items: leftItems,
+    queryBatch,
+    shouldFallback
+  })
+  if (leftResult.error) {
+    return { error: leftResult.error }
+  }
+
+  const rightResult = await queryArrayWith414Fallback({
+    items: rightItems,
+    queryBatch,
+    shouldFallback
+  })
+  if (rightResult.error) {
+    return { error: rightResult.error }
+  }
+
+  return {
+    data: [...(leftResult.data ?? []), ...(rightResult.data ?? [])]
+  }
+}

--- a/app/modules/utils/api/tdxQuery.test.ts
+++ b/app/modules/utils/api/tdxQuery.test.ts
@@ -3,10 +3,11 @@ import { CityNameType } from '../../enums/CityNameType'
 import {
   buildNearbyStopOfRouteQuery,
   buildNearbyStopQuery,
+  buildStopsByCityAndIdsQuery,
   getNearbyStopBounds
-} from './buildNearbyStopQuery'
+} from './tdxQuery'
 
-describe('buildNearbyStopQuery', () => {
+describe('tdxQuery', () => {
   it('builds bounded coordinates around the current position', () => {
     expect(getNearbyStopBounds([25.033, 121.5654])).toEqual({
       latitudeMin: expect.any(Number),
@@ -16,7 +17,7 @@ describe('buildNearbyStopQuery', () => {
     })
   })
 
-  it('builds a stop query with select, filter, and format parameters', () => {
+  it('builds a nearby stop query with select, filter, and format parameters', () => {
     const query = buildNearbyStopQuery(CityNameType.NEW_TAIPEI, [25.033, 121.5654])
 
     expect(query).toContain('/Stop/City/NewTaipei?')
@@ -33,6 +34,17 @@ describe('buildNearbyStopQuery', () => {
     expect(query).toContain('Stops%2Fany')
     expect(query).toContain('d%2FStopUID+eq+%27stop-1%27')
     expect(query).toContain('d%2FStopUID+eq+%27stop-2%27')
+    expect(query).toContain('%24format=JSON')
+  })
+
+  it('builds a stop query that filters by stop uid or stop id', () => {
+    const query = buildStopsByCityAndIdsQuery(CityNameType.TAIPEI, ['stop-1', "stop'2"])
+
+    expect(query).toContain('/Stop/City/Taipei?')
+    expect(query).toContain('%24filter=')
+    expect(query).toContain("StopUID%20eq%20'stop-1'")
+    expect(query).toContain("StopID%20eq%20'stop-1'")
+    expect(query).toContain("stop''2")
     expect(query).toContain('%24format=JSON')
   })
 })

--- a/app/modules/utils/api/tdxQuery.ts
+++ b/app/modules/utils/api/tdxQuery.ts
@@ -1,7 +1,7 @@
-import type { CityNameType } from '../../enums/CityNameType'
 import { NEARBY_DISTANCE_KM } from '../../consts/nearby'
+import type { CityNameType } from '../../enums/CityNameType'
 import type { LatLng } from '../../types/CoordsType'
-import { getLatitudeKilometersPerDegree, getLongitudeKilometersPerDegree } from './getGeoKilometersPerDegree'
+import { getLatitudeKilometersPerDegree, getLongitudeKilometersPerDegree } from '../geo/getGeoKilometersPerDegree'
 
 const STOP_SELECT_FIELDS = [
   'StopUID',
@@ -24,6 +24,10 @@ interface NearbyStopBounds {
   latitudeMax: number
   longitudeMin: number
   longitudeMax: number
+}
+
+function quoteODataString(value: string): string {
+  return value.replace(/'/g, "''")
 }
 
 export function getNearbyStopBounds(
@@ -67,9 +71,20 @@ export function buildNearbyStopOfRouteQuery(city: CityNameType, stopUIDs: string
   if (stopUIDs.length > 0) {
     searchParams.set(
       '$filter',
-      `Stops/any(d:(${stopUIDs.map((stopUID) => `d/StopUID eq '${stopUID}'`).join(' or ')}))`
+      `Stops/any(d:(${stopUIDs.map((stopUID) => `d/StopUID eq '${quoteODataString(stopUID)}'`).join(' or ')}))`
     )
   }
 
   return `/StopOfRoute/City/${city}?${searchParams.toString()}`
+}
+
+export function buildStopsByCityAndIdsQuery(city: CityNameType, stopIds: string[]): string {
+  const filter = stopIds
+    .map((stopId) => {
+      const quotedStopId = quoteODataString(stopId)
+      return `(StopUID eq '${quotedStopId}' or StopID eq '${quotedStopId}')`
+    })
+    .join(' or ')
+
+  return `/Stop/City/${city}?%24filter=${encodeURIComponent(filter)}&%24format=JSON`
 }

--- a/app/modules/utils/i18n/getBearingTranslationKey.ts
+++ b/app/modules/utils/i18n/getBearingTranslationKey.ts
@@ -1,0 +1,6 @@
+import { bearingTranslationKeyMap } from '../../consts/bearing'
+import { BearingType } from '../../enums/BearingType'
+
+export function getBearingTranslationKey(bearing: BearingType) {
+  return bearingTranslationKeyMap[bearing]
+}

--- a/app/modules/utils/nearby/getStopGroupBearingLabel.test.ts
+++ b/app/modules/utils/nearby/getStopGroupBearingLabel.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { BearingType } from '~/modules/enums/BearingType'
+import { CityNameType } from '~/modules/enums/CityNameType'
+import type { NearbyStopGroup } from '~/modules/interfaces/Nearby'
+import { getStopGroupBearingLabel } from './getStopGroupBearingLabel'
+
+const stopGroupBase: NearbyStopGroup = {
+  StationID: 'station-1',
+  StopName: { 'zh-TW': '市政府', en: 'City Hall' },
+  City: CityNameType.TAIPEI,
+  position: [121.5654, 25.033],
+  stops: []
+}
+
+describe('getStopGroupBearingLabel', () => {
+  const t = (key: string) => key
+
+  it('returns one bearing label when all stops share the same bearing', () => {
+    expect(getStopGroupBearingLabel(t, {
+      ...stopGroupBase,
+      stops: [
+        { Bearing: BearingType.EAST } as NearbyStopGroup['stops'][number],
+        { Bearing: BearingType.EAST } as NearbyStopGroup['stops'][number]
+      ]
+    })).toBe('common.bearing.east')
+  })
+
+  it('returns combined bearing labels when stop bearings differ', () => {
+    expect(getStopGroupBearingLabel(t, {
+      ...stopGroupBase,
+      stops: [
+        { Bearing: BearingType.EAST } as NearbyStopGroup['stops'][number],
+        { Bearing: BearingType.WEST } as NearbyStopGroup['stops'][number]
+      ]
+    })).toBe('common.bearing.east / common.bearing.west')
+  })
+
+  it('returns null when no stop has a bearing value', () => {
+    expect(getStopGroupBearingLabel(t, {
+      ...stopGroupBase,
+      stops: [{ Bearing: null } as NearbyStopGroup['stops'][number]]
+    })).toBeNull()
+  })
+})

--- a/app/modules/utils/nearby/getStopGroupBearingLabel.ts
+++ b/app/modules/utils/nearby/getStopGroupBearingLabel.ts
@@ -1,6 +1,12 @@
 import { BearingType } from '~/modules/enums/BearingType'
 import type { NearbyStopGroup } from '~/modules/interfaces/Nearby'
 import { getBearingTranslationKey } from '~/modules/utils/i18n/getBearingTranslationKey'
+import { getEnumValues } from '~/modules/utils/shared/getEnumValues'
+
+const bearingSortOrder = getEnumValues(BearingType).reduce<Record<BearingType, number>>((result, bearing, index) => {
+  result[bearing] = index
+  return result
+}, {} as Record<BearingType, number>)
 
 export function getStopGroupBearingLabel(
   t: (key: string) => string,
@@ -10,7 +16,7 @@ export function getStopGroupBearingLabel(
     stopGroup.stops
       .map((stop) => stop.Bearing)
       .filter((bearing): bearing is BearingType => bearing != null)
-  ))
+  )).sort((left, right) => bearingSortOrder[left] - bearingSortOrder[right])
 
   if (bearings.length === 0) {
     return null

--- a/app/modules/utils/nearby/getStopGroupBearingLabel.ts
+++ b/app/modules/utils/nearby/getStopGroupBearingLabel.ts
@@ -1,0 +1,22 @@
+import { BearingType } from '~/modules/enums/BearingType'
+import type { NearbyStopGroup } from '~/modules/interfaces/Nearby'
+import { getBearingTranslationKey } from '~/modules/utils/i18n/getBearingTranslationKey'
+
+export function getStopGroupBearingLabel(
+  t: (key: string) => string,
+  stopGroup: NearbyStopGroup
+): string | null {
+  const bearings = Array.from(new Set(
+    stopGroup.stops
+      .map((stop) => stop.Bearing)
+      .filter((bearing): bearing is BearingType => bearing != null)
+  ))
+
+  if (bearings.length === 0) {
+    return null
+  }
+
+  return bearings
+    .map((bearing) => t(getBearingTranslationKey(bearing)))
+    .join(' / ')
+}

--- a/app/pages/Nearby.test.tsx
+++ b/app/pages/Nearby.test.tsx
@@ -466,7 +466,7 @@ describe('Nearby', () => {
       skip: true
     })
 
-    fireEvent.click(screen.getByRole('button', { name: '市政府' }))
+    fireEvent.click(screen.getByRole('button', { name: /^市政府/ }))
 
     expect(mockUseGetRoutesByAreaQuery).toHaveBeenLastCalledWith(expect.anything(), {
       skip: true
@@ -606,7 +606,7 @@ describe('Nearby', () => {
       }
     })
 
-    fireEvent.click(screen.getByRole('button', { name: '市政府' }))
+    fireEvent.click(screen.getByRole('button', { name: /^市政府/ }))
 
     const updatedProps = mockNearbyStopMap.mock.calls.at(-1)?.[0]
     expect(updatedProps?.selectedStop).toBe('station-1')
@@ -628,7 +628,7 @@ describe('Nearby', () => {
       firstRenderProps?.onSelectStop('station-1')
     })
 
-    expect(screen.getByRole('button', { name: '市政府' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('button', { name: /^市政府/ })).toHaveAttribute('aria-expanded', 'true')
   })
 })
 

--- a/app/pages/Route.test.tsx
+++ b/app/pages/Route.test.tsx
@@ -31,7 +31,7 @@ const {
   mockUseGetRouteShapesByRouteQuery,
   mockUseGetRoutesByCityQuery,
   mockUseGetStopOfRoutesByCityQuery,
-  mockUseGetStopsByCityQuery,
+  mockUseGetStopsByCityAndIdsQuery,
   mockRouteMap
 } = vi.hoisted(() => ({
   mockToggleFavoriteRouteStop: vi.fn(),
@@ -41,7 +41,7 @@ const {
   mockUseGetRouteShapesByRouteQuery: vi.fn(),
   mockUseGetRoutesByCityQuery: vi.fn(),
   mockUseGetStopOfRoutesByCityQuery: vi.fn(),
-  mockUseGetStopsByCityQuery: vi.fn(),
+  mockUseGetStopsByCityAndIdsQuery: vi.fn(),
   mockRouteMap: vi.fn(({
     extraControls
   }: {
@@ -82,7 +82,7 @@ vi.mock('~/modules/apis/bus', () => ({
     useGetRouteShapesByRouteQuery: mockUseGetRouteShapesByRouteQuery,
     useGetRoutesByCityQuery: mockUseGetRoutesByCityQuery,
     useGetStopOfRoutesByCityQuery: mockUseGetStopOfRoutesByCityQuery,
-    useGetStopsByCityQuery: mockUseGetStopsByCityQuery
+    useGetStopsByCityAndIdsQuery: mockUseGetStopsByCityAndIdsQuery
   }
 }))
 
@@ -322,7 +322,7 @@ function resetRouteMocks() {
   mockUseGetRouteShapesByRouteQuery.mockReset()
   mockUseGetRoutesByCityQuery.mockReset()
   mockUseGetStopOfRoutesByCityQuery.mockReset()
-  mockUseGetStopsByCityQuery.mockReset()
+  mockUseGetStopsByCityAndIdsQuery.mockReset()
   mockRouteMap.mockClear()
 }
 
@@ -339,7 +339,7 @@ function mockDefaultRouteQueries() {
     error: null
   })
 
-  mockUseGetStopsByCityQuery.mockReturnValue({
+  mockUseGetStopsByCityAndIdsQuery.mockReturnValue({
     data: stopsByCityData,
     isLoading: false,
     error: null
@@ -464,7 +464,7 @@ describe('Route', () => {
       isLoading: true,
       error: null
     })
-    mockUseGetStopsByCityQuery.mockReturnValue({
+    mockUseGetStopsByCityAndIdsQuery.mockReturnValue({
       data: [],
       isLoading: true,
       error: null

--- a/app/pages/Route.tsx
+++ b/app/pages/Route.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Flex, Stack, Tabs, Text, useMantineTheme } from '@mantine/core'
-import { useDisclosure, useMediaQuery } from '@mantine/hooks'
+import { useMediaQuery } from '@mantine/hooks'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -11,6 +11,7 @@ import { RouteStopList } from '~/components/route/RouteStopList'
 import { useFavoriteRouteStops } from '~/modules/hooks/useFavoriteRouteStops'
 import { useRouteBaseData } from '~/modules/hooks/useRouteBaseData'
 import { useRouteRealtimeData } from '~/modules/hooks/useRouteRealtimeData'
+import { useRouteSelectionState } from '~/modules/hooks/useRouteSelectionState'
 import { RiArrowLeftSLine, RiMenuFill } from '@remixicon/react'
 import { AppBadge } from '~/components/common/AppBadge'
 import { selectLocale } from '~/modules/slices/localeSlice'
@@ -27,12 +28,8 @@ export default function Route() {
   const navigate = useNavigate()
   const theme = useMantineTheme()
   const isSm = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`)
-  const [isSidebarOpened, { open: openSidebar, close: closeSidebar }] = useDisclosure(false)
-  const [listScrollBehavior, setListScrollBehavior] = useState<ScrollLogicalPosition>('nearest')
   const { isFavoriteRouteStop, toggleFavoriteRouteStop } = useFavoriteRouteStops()
   const [activeTab, setActiveTab] = useState<string | null>(null)
-  const [selectedStopId, setSelectedStopId] = useState<string | null>(null)
-  const [selectedVehicleId, setSelectedVehicleId] = useState<string | null>(null)
   const routeBaseOptions = city && isCityName(city) && id
     ? {
         activeTab,
@@ -79,6 +76,24 @@ export default function Route() {
       null,
     realtimeBuses: realtimeBusesByStopSequence.get(stop.sequence) ?? []
   })), [baseStops, estimatedArrivalLabelsByStopKey, realtimeBusesByStopSequence])
+  const {
+    closeSidebar,
+    handleSelectStopFromList,
+    handleSelectStopFromMap,
+    handleSelectVehicleFromList,
+    handleSelectVehicleFromMap,
+    isSidebarOpened,
+    listScrollBehavior,
+    openSidebar,
+    selectedStopId,
+    selectedVehicleId
+  } = useRouteSelectionState({
+    defaultActiveTabId,
+    isSm,
+    routeTabs,
+    setActiveTab,
+    stops
+  })
   const selectedStopEstimatedArrivalLabel = useMemo(
     () => stops.find((stop) => stop.id === selectedStopId)?.estimatedArrivalLabel ?? null,
     [selectedStopId, stops]
@@ -89,78 +104,12 @@ export default function Route() {
   const routeTerminalDisplay = getTerminalDisplay(routeDeparture, routeDestination, ' - ')
 
   useEffect(() => {
-    if (isSm) {
-      openSidebar()
-      return
-    }
-  }, [isSm, openSidebar])
-
-  useEffect(() => {
     if (!city || !isCityName(city) || !id) {
       return
     }
 
     saveRouteSearchRecent(id)
   }, [city, id])
-
-  useEffect(() => {
-    if (!routeTabs.length) {
-      setActiveTab(null)
-      return
-    }
-
-    setActiveTab((currentTab) => {
-      if (currentTab && routeTabs.some((tab) => tab.id === currentTab)) {
-        return currentTab
-      }
-      return defaultActiveTabId
-    })
-  }, [defaultActiveTabId, routeTabs])
-
-  useEffect(() => {
-    if (!selectedStopId) return
-    if (stops.some((stop) => stop.id === selectedStopId)) return
-
-    setSelectedStopId(null)
-  }, [selectedStopId, stops])
-
-  useEffect(() => {
-    if (!selectedVehicleId) return
-    if (stops.some((stop) => stop.realtimeBuses.some((bus) => bus.id === selectedVehicleId))) return
-
-    setSelectedVehicleId(null)
-  }, [selectedVehicleId, stops])
-
-  const handleSelectStopFromList = useCallback((stopId: string) => {
-    setListScrollBehavior('nearest')
-    setSelectedStopId(stopId)
-    setSelectedVehicleId(null)
-
-    if (isSm) {
-      closeSidebar()
-    }
-  }, [closeSidebar, isSm])
-
-  const handleSelectVehicleFromList = useCallback((vehicleId: string) => {
-    setSelectedVehicleId(vehicleId)
-    setSelectedStopId(null)
-
-    if (isSm) {
-      closeSidebar()
-    }
-  }, [closeSidebar, isSm])
-
-  const handleSelectVehicleFromMap = useCallback((vehicleId: string) => {
-    setListScrollBehavior('start')
-    setSelectedVehicleId(vehicleId)
-    setSelectedStopId(null)
-  }, [])
-
-  const handleSelectStopFromMap = useCallback((stopId: string | null) => {
-    setListScrollBehavior('start')
-    setSelectedStopId(stopId)
-    setSelectedVehicleId(null)
-  }, [])
 
   const handleBack = useCallback(() => {
     if ((window.history.state?.idx ?? 0) > 0) {
@@ -195,7 +144,7 @@ export default function Route() {
           </Stack>
           {routeTabs.length > 0
             ? (
-            <Tabs
+              <Tabs
               value={activeTab}
               onChange={setActiveTab}
               keepMounted={false}

--- a/app/pages/Route.tsx
+++ b/app/pages/Route.tsx
@@ -43,7 +43,8 @@ export default function Route() {
       }
     : null
   const {
-    activeSubRoute,
+    subRoute,
+    routePath,
     baseStops,
     busRoute,
     highlightedStopId,
@@ -54,16 +55,15 @@ export default function Route() {
     routeMapStops,
     routeTabs
   } = useRouteBaseData(routeBaseOptions)
-  const routeRealtimeOptions = city && isCityName(city) && id && busRoute && activeSubRoute
+  const routeRealtimeOptions = city && isCityName(city) && id && busRoute && subRoute
     ? {
-        activeSubRoute,
+        subRoute,
         busRoute,
         city,
         id
       }
     : null
   const {
-    activeRoutePath,
     estimatedArrivalLabelsByStopKey,
     hasRealtimeError,
     isRealtimeLoading,
@@ -270,7 +270,7 @@ export default function Route() {
         selectedVehicleId={selectedVehicleId}
         onSelectStop={handleSelectStopFromMap}
         onSelectVehicle={handleSelectVehicleFromMap}
-        routePath={activeRoutePath}
+        routePath={routePath}
         stops={routeMapStops}
         selectedStopEstimatedArrivalLabel={selectedStopEstimatedArrivalLabel}
         vehicles={realtimeMapVehicles}


### PR DESCRIPTION
## Summary

Refactor Route/Nearby data flow for better UX and maintainability:
- Route requests now handle URI-too-long retries more robustly.
- Route page state/data hooks are cleaner.
- Nearby same-name opposite-side stops are easier to distinguish with bearing labels.

## What Changed

- Route/API refactor
  - Moved TDX query builders into `utils/api/tdxQuery`.
  - Added shared `queryArrayWith414Fallback` and applied it to batched array queries.
  - Extended 414 fallback to also handle `PARSING_ERROR + originalStatus=414`.
  - Suppressed global refresh modal for 414 responses.
- Route page cleanup
  - Moved shape/path ownership into base route data flow.
  - Renamed `activeSubRoute`/`activeRoutePath` to `subRoute`/`routePath`.
  - Extracted `useRouteSelectionState` to reduce `Route.tsx` complexity.
  - Reused `activeRouteTab` in `useRouteBaseData` to avoid duplicated tab lookup.
- Nearby UX improvement
  - Added localized bearing labels (`往東/往西...`, `Eastbound/Westbound...`) to distinguish opposite-side same-name stops.
  - Surfaced bearing labels in nearby list/title/detail contexts.

## Validation

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`

## Scope Notes

- No changes to station grouping semantics (`StationID` grouping remains unchanged).
- This PR improves direction clarity in UI and 414 resilience; it does not redesign Nearby route tab behavior.

## Reviewer Notes

Please focus on:
- `app/modules/apis/bus.ts`
- `app/modules/utils/api/queryWith414Fallback.ts`
- `app/modules/apis/errors/busError.ts`
- `app/modules/hooks/useRouteBaseData.ts`
- `app/modules/hooks/useRouteSelectionState.ts`
- `app/components/nearby/NearbySidebarContent.tsx`
- `app/components/nearby/NearbyStopDetail.tsx`
