### PR TITLE
feat(analytics): add GA4 pageview tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VITE_PROXY_API_BASE_URL: ${{ vars.VITE_PROXY_API_BASE_URL }}
+      VITE_GA_ID: ${{ vars.VITE_GA_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-pnpm

--- a/README.md
+++ b/README.md
@@ -195,4 +195,5 @@ The frontend is deployed as a static app, while TDX authentication is handled by
 1. Store `TDX_CLIENT_ID`, `TDX_CLIENT_SECRET`, and `ALLOWED_ORIGINS` in Cloudflare Worker environment bindings.
 2. Deploy the Worker with `pnpm run deploy:proxy`.
 3. Store `VITE_PROXY_API_BASE_URL` as a GitHub Actions repository variable.
-4. Let the GitHub Pages build inject that value during `pnpm run build`.
+4. Optional: store `VITE_GA_ID` as a GitHub Actions repository variable to enable GA4 pageview tracking.
+5. Let the GitHub Pages build inject those values during `pnpm run build`.

--- a/app/modules/hooks/useGoogleAnalytics.ts
+++ b/app/modules/hooks/useGoogleAnalytics.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router'
+import {
+  initializeGoogleAnalytics,
+  trackGoogleAnalytics
+} from '~/modules/utils/shared/googleAnalytics'
+
+export function useGoogleAnalytics() {
+  const location = useLocation()
+
+  useEffect(() => {
+    const isGoogleAnalyticsReady = initializeGoogleAnalytics()
+
+    if (!isGoogleAnalyticsReady) {
+      return
+    }
+
+    const pagePath = `${location.pathname}${location.search}${location.hash}`
+
+    trackGoogleAnalytics(pagePath)
+  }, [location.pathname, location.search, location.hash])
+}

--- a/app/modules/utils/shared/googleAnalytics.test.ts
+++ b/app/modules/utils/shared/googleAnalytics.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  initializeGoogleAnalytics,
+  resetGoogleAnalyticsForTest,
+  trackGoogleAnalytics
+} from './googleAnalytics'
+
+const GA_ID = 'G-TEST123456'
+
+describe('googleAnalytics', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_GA_ID', GA_ID)
+    resetGoogleAnalyticsForTest()
+    document.getElementById('google-analytics-gtag-script')?.remove()
+    delete window.gtag
+    delete window.dataLayer
+    document.title = 'Test Page'
+    window.history.replaceState({}, '', '/routes?city=Taipei#detail')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    resetGoogleAnalyticsForTest()
+
+    const script = document.getElementById('google-analytics-gtag-script')
+    script?.remove()
+
+    delete window.gtag
+    delete window.dataLayer
+  })
+
+  it('initializes GA when measurement id is provided', () => {
+    const initialized = initializeGoogleAnalytics()
+
+    expect(initialized).toBe(true)
+
+    const script = document.getElementById('google-analytics-gtag-script')
+    expect(script).not.toBeNull()
+
+    expect(window.gtag).toBeDefined()
+    expect(window.dataLayer?.length).toBe(2)
+  })
+
+  it('tracks page view with path and title', () => {
+    initializeGoogleAnalytics()
+
+    trackGoogleAnalytics('/routes?city=Taipei#detail')
+
+    expect(window.dataLayer?.length).toBe(3)
+
+    const pageViewEvent = window.dataLayer?.[2] as [string, string, Record<string, unknown>]
+
+    expect(pageViewEvent[0]).toBe('event')
+    expect(pageViewEvent[1]).toBe('page_view')
+    expect(pageViewEvent[2]).toMatchObject({
+      page_title: 'Test Page',
+      page_path: '/routes?city=Taipei#detail',
+      send_to: GA_ID
+    })
+  })
+
+  it('does nothing when measurement id is missing', () => {
+    vi.stubEnv('VITE_GA_ID', '')
+
+    const initialized = initializeGoogleAnalytics()
+
+    expect(initialized).toBe(false)
+
+    trackGoogleAnalytics('/routes')
+
+    expect(document.getElementById('google-analytics-gtag-script')).toBeNull()
+    expect(window.dataLayer).toBeUndefined()
+  })
+})

--- a/app/modules/utils/shared/googleAnalytics.ts
+++ b/app/modules/utils/shared/googleAnalytics.ts
@@ -1,0 +1,98 @@
+const GA_SCRIPT_ID = 'google-analytics-gtag-script'
+const GA_DEBUG_QUERY_KEY = 'ga_debug'
+const GA_DEBUG_ENABLED_VALUE = '1'
+
+let isInitialized = false
+
+function isBrowserEnvironment () {
+  return typeof window !== 'undefined' && typeof document !== 'undefined'
+}
+
+function getGaMeasurementId () {
+  const gaId = import.meta.env.VITE_GA_ID
+  return gaId || undefined
+}
+
+function isGaDebugEnabled () {
+  if (!isBrowserEnvironment()) return false
+  const debugValue = new URLSearchParams(window.location.search).get(GA_DEBUG_QUERY_KEY)
+  return debugValue === GA_DEBUG_ENABLED_VALUE
+}
+
+function logGaDebug (...args: unknown[]) {
+  if (!isGaDebugEnabled()) return
+  console.info('[ga-debug]', ...args)
+}
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+export function initializeGoogleAnalytics () {
+  const gaId = getGaMeasurementId()
+  if (!gaId || !isBrowserEnvironment()) return false
+
+  if (isInitialized && window.gtag) return true
+
+  const existingScript = document.getElementById(GA_SCRIPT_ID)
+
+  if (!existingScript) {
+    const script = document.createElement('script')
+    script.id = GA_SCRIPT_ID
+    script.async = true
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`
+    document.head.appendChild(script)
+  }
+
+  const dataLayer = window.dataLayer ?? []
+  window.dataLayer = dataLayer
+
+  function gtag () {
+    // eslint-disable-next-line prefer-rest-params
+    dataLayer.push(arguments)
+  }
+
+  window.gtag = window.gtag || gtag
+
+  logGaDebug('initialize', {
+    measurementId: gaId,
+    hasExistingScript: Boolean(existingScript)
+  })
+
+  window.gtag('js', new Date())
+  window.gtag('config', gaId, {
+    send_page_view: false
+  })
+
+  isInitialized = true
+
+  return true
+}
+
+export function trackGoogleAnalytics (pagePath: string) {
+  const gaId = getGaMeasurementId()
+  if (!gaId || !isBrowserEnvironment() || !window.gtag) {
+    return
+  }
+
+  logGaDebug('page_view', {
+    pageTitle: document.title,
+    pageLocation: window.location.href,
+    pagePath,
+    measurementId: gaId
+  })
+
+  window.gtag('event', 'page_view', {
+    page_title: document.title,
+    page_location: window.location.href,
+    page_path: pagePath,
+    send_to: gaId
+  })
+}
+
+export function resetGoogleAnalyticsForTest () {
+  isInitialized = false
+}

--- a/app/pages/AppLayout.tsx
+++ b/app/pages/AppLayout.tsx
@@ -21,6 +21,7 @@ import {
   APP_HEADER_HEIGHT
 } from '~/modules/consts/layout'
 import { useWatchGeo } from '~/modules/hooks/useWatchGeo'
+import { useGoogleAnalytics } from '~/modules/hooks/useGoogleAnalytics'
 import { fetchCityGeoJSON } from '~/modules/slices/cityGeoSlice'
 import type { AppDispatch, RootState } from '~/modules/store'
 
@@ -65,6 +66,7 @@ export default function AppLayout () {
   const isSettingsPage = location.pathname === settingNav.path
 
   useWatchGeo()
+  useGoogleAnalytics()
 
   useEffect(() => {
     if (geojson) return

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ViteTypeOptions {
 
 interface ImportMetaEnv {
   readonly VITE_PROXY_API_BASE_URL?: string
+  readonly VITE_GA_ID?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Enable GA4 pageview tracking for the SPA and make deployment configuration explicit so analytics can be turned on safely per environment.

## What Changed

- Added a shared GA utility to initialize `gtag.js` and send `page_view` events.
- Added `useGoogleAnalytics` and wired it in `AppLayout` to track route changes.
- Added unit tests for GA initialization and pageview tracking behavior.
- Added `VITE_GA_ID` typing support.
- Updated deploy workflow to inject `VITE_GA_ID` at build time.
- Updated README deployment notes with optional GA setup.

## Validation

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [ ] `pnpm run test` (full suite not run in this round)
- [x] `pnpm test app/modules/utils/shared/googleAnalytics.test.ts`
- [x] Local manual check: `page_view` is emitted and received in GA (Realtime/Debug path verified).

## Scope Notes

- This PR only covers GA4 pageview tracking and deployment wiring.
- No custom GA events or consent UI flow are included yet.

## Reviewer Notes

- Please pay extra attention to:
  - `app/modules/utils/shared/googleAnalytics.ts`
  - `app/modules/hooks/useGoogleAnalytics.ts`
  - `.github/workflows/deploy.yml`
- Reason for adding deploy/env settings: without `VITE_GA_ID` injected at build time, the tracker exits early and no analytics requests are sent.
