### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,9 @@ name: PR Checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   workspace-checks:
     name: ${{ matrix.workspace }} / ${{ matrix.command }}


### PR DESCRIPTION
Potential fix for [https://github.com/clhuang224/bus/security/code-scanning/1](https://github.com/clhuang224/bus/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/pr-checks.yml` at the workflow root level (right after `on:` is a clean location) so all jobs inherit least-privilege access unless overridden. For this workflow, the minimal required permission is `contents: read`, which is sufficient for `actions/checkout` and running checks. This preserves existing functionality while ensuring token scope is explicitly constrained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
