### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
   web-checks:
     name: ${{ matrix.command }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -21,6 +23,9 @@ jobs:
   build-web:
     needs: web-checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
     env:
       VITE_PROXY_API_BASE_URL: ${{ vars.VITE_PROXY_API_BASE_URL }}
       VITE_GA_ID: ${{ vars.VITE_GA_ID }}


### PR DESCRIPTION
Potential fix for [https://github.com/clhuang224/bus/security/code-scanning/2](https://github.com/clhuang224/bus/security/code-scanning/2)

Add explicit `permissions` for the jobs that currently lack them, using least privilege:

- `web-checks`: `contents: read` (needed for checkout and running checks).
- `build-web`: `contents: read` (checkout/build) and `pages: write` (required for `actions/upload-pages-artifact`/Pages flow).
- Keep existing `deploy` permissions unchanged (`contents: read`, `pages: write`, `id-token: write`).

This avoids changing behavior while ensuring every job has explicit token scope.  
Edit only `.github/workflows/deploy.yml`, inserting job-level `permissions` blocks directly under each job’s `runs-on` line (or near top of each job stanza).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
