### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   web-checks:
     name: ${{ matrix.command }}


### PR DESCRIPTION
Potential fix for [https://github.com/clhuang224/bus/security/code-scanning/3](https://github.com/clhuang224/bus/security/code-scanning/3)

Add an explicit top-level `permissions` block to `.github/workflows/deploy.yml` so all jobs default to least privilege.  
Best fix without changing functionality: add at workflow root:

- `permissions:`
  - `contents: read`

This safely covers `actions/checkout` usage in `web-checks` and `build-web`, and keeps existing `deploy` job behavior unchanged because job-level permissions override workflow-level defaults (so `pages: write` and `id-token: write` remain for deploy only).

Change location: insert the new block between `on:` trigger section and `jobs:` section.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
