### PR TITLE
feat(api): extend Prisma schema for backend data planning

### DIFF
--- a/apps/api/docs/database-plan.md
+++ b/apps/api/docs/database-plan.md
@@ -485,7 +485,7 @@ Fields:
 
 Indexes:
 
-- unique `subroute_id + stop_id + sequence`
+- unique `subroute_id + sequence`
 - index `stop_id`
 - index `subroute_id + sequence`
 

--- a/apps/api/docs/database-plan.md
+++ b/apps/api/docs/database-plan.md
@@ -147,9 +147,9 @@ TDX may provide short direction codes. The database should store readable string
 
 #### `sync_status`
 
-- `pending`
+- `queued`
 - `running`
-- `success`
+- `succeeded`
 - `failed`
 
 ## Relationship Draft
@@ -589,9 +589,9 @@ Possible `resource` values:
 
 Possible `status` values:
 
-- `pending`
+- `queued`
 - `running`
-- `success`
+- `succeeded`
 - `failed`
 
 ### sync_error

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,17 +5,20 @@
   "type": "module",
   "scripts": {
     "build": "nest build",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "format": "concurrently \"prettier --write \\\"src/**/*.ts\\\" \\\"test/**/*.ts\\\"\" \"prisma format\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main.js",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
+    "lint": "concurrently \"eslint \\\"{src,test}/**/*.ts\\\"\" \"prisma validate\"",
+    "prisma:format": "prisma format",
+    "prisma:validate": "prisma validate",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:cov": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config ./test/jest-e2e.json"
+    "test:e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config ./test/jest-e2e.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@bus/shared": "workspace:*",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,10 +13,8 @@
     "lint": "concurrently \"eslint \\\"{src,test}/**/*.ts\\\"\" \"prisma validate\"",
     "prisma:format": "prisma format",
     "prisma:validate": "prisma validate",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
-    "test:cov": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test": "concurrently \"pnpm run test:unit\" \"pnpm run test:e2e\"",
+    "test:unit": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "NODE_OPTIONS=--experimental-vm-modules jest --config ./test/jest-e2e.json",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/apps/api/prisma/enums/app-locale-type.prisma
+++ b/apps/api/prisma/enums/app-locale-type.prisma
@@ -1,6 +1,4 @@
 enum AppLocaleType {
   ZH_TW @map("zh-TW")
   EN    @map("en")
-  JA    @map("ja")
-  KO    @map("ko")
 }

--- a/apps/api/prisma/enums/app-locale-type.prisma
+++ b/apps/api/prisma/enums/app-locale-type.prisma
@@ -1,4 +1,6 @@
 enum AppLocaleType {
   ZH_TW @map("zh-TW")
   EN    @map("en")
+  JA    @map("ja")
+  KO    @map("ko")
 }

--- a/apps/api/prisma/enums/app-locale-type.prisma
+++ b/apps/api/prisma/enums/app-locale-type.prisma
@@ -1,0 +1,4 @@
+enum AppLocaleType {
+  ZH_TW @map("zh-TW")
+  EN    @map("en")
+}

--- a/apps/api/prisma/enums/route-shape-source.prisma
+++ b/apps/api/prisma/enums/route-shape-source.prisma
@@ -1,0 +1,5 @@
+enum RouteShapeSource {
+  ENCODED_POLYLINE @map("encoded_polyline")
+  GEOMETRY          @map("geometry")
+  STOP_POSITIONS    @map("stop_positions")
+}

--- a/apps/api/prisma/enums/sync-resource-type.prisma
+++ b/apps/api/prisma/enums/sync-resource-type.prisma
@@ -1,0 +1,6 @@
+enum SyncResourceType {
+  ROUTES   @map("routes")
+  STOPS    @map("stops")
+  STATIONS @map("stations")
+  SHAPES   @map("shapes")
+}

--- a/apps/api/prisma/enums/sync-status-type.prisma
+++ b/apps/api/prisma/enums/sync-status-type.prisma
@@ -1,0 +1,6 @@
+enum SyncStatusType {
+  QUEUED    @map("queued")
+  RUNNING   @map("running")
+  SUCCEEDED @map("succeeded")
+  FAILED    @map("failed")
+}

--- a/apps/api/prisma/models/favorite-route-stop.prisma
+++ b/apps/api/prisma/models/favorite-route-stop.prisma
@@ -1,0 +1,22 @@
+model FavoriteRouteStop {
+  id            String        @id @default(uuid()) @db.Uuid
+  uuid          String        @unique @db.VarChar(64)
+  user_id       String        @db.Uuid
+  user          User          @relation(fields: [user_id], references: [id])
+  route_id      String        @db.Uuid
+  route         Route         @relation(fields: [route_id], references: [id])
+  subroute_id   String        @db.Uuid
+  subroute      SubRoute      @relation(fields: [subroute_id], references: [id])
+  stop_id       String        @db.Uuid
+  stop          Stop          @relation(fields: [stop_id], references: [id])
+  direction     DirectionType
+  stop_sequence Int
+  created_at    DateTime      @default(now())
+  updated_at    DateTime      @updatedAt
+
+  @@unique([user_id, route_id, subroute_id, stop_id, direction])
+  @@index([route_id])
+  @@index([subroute_id])
+  @@index([stop_id])
+  @@map("favorite_route_stop")
+}

--- a/apps/api/prisma/models/operator.prisma
+++ b/apps/api/prisma/models/operator.prisma
@@ -1,0 +1,15 @@
+model Operator {
+  id               String          @id @default(uuid()) @db.Uuid
+  tdx_operator_id  String          @unique @db.VarChar(64)
+  name_zh_tw       String          @db.VarChar(100)
+  name_en          String?         @db.VarChar(100)
+  phone            String?         @db.VarChar(50)
+  website_url      String?         @db.Text
+  is_active        Boolean         @default(true)
+  inactive_at      DateTime?
+  created_at       DateTime        @default(now())
+  updated_at       DateTime        @updatedAt
+  route_operators  RouteOperator[]
+
+  @@map("operator")
+}

--- a/apps/api/prisma/models/route-operator.prisma
+++ b/apps/api/prisma/models/route-operator.prisma
@@ -1,0 +1,10 @@
+model RouteOperator {
+  route_id    String   @db.Uuid
+  route       Route    @relation(fields: [route_id], references: [id])
+  operator_id String   @db.Uuid
+  operator    Operator @relation(fields: [operator_id], references: [id])
+
+  @@id([route_id, operator_id])
+  @@index([operator_id])
+  @@map("route_operator")
+}

--- a/apps/api/prisma/models/route-shape.prisma
+++ b/apps/api/prisma/models/route-shape.prisma
@@ -1,0 +1,16 @@
+model RouteShape {
+  id               String           @id @default(uuid()) @db.Uuid
+  subroute_id      String           @unique @db.Uuid
+  subroute         SubRoute         @relation(fields: [subroute_id], references: [id])
+  source           RouteShapeSource
+  path             Json
+  encoded_polyline String?          @db.Text
+  geometry         String?          @db.Text
+  is_active        Boolean          @default(true)
+  inactive_at      DateTime?
+  tdx_updated_at   DateTime?
+  created_at       DateTime         @default(now())
+  updated_at       DateTime         @updatedAt
+
+  @@map("route_shape")
+}

--- a/apps/api/prisma/models/route-stop.prisma
+++ b/apps/api/prisma/models/route-stop.prisma
@@ -1,0 +1,18 @@
+model RouteStop {
+  id             String    @id @default(uuid()) @db.Uuid
+  subroute_id    String    @db.Uuid
+  subroute       SubRoute  @relation(fields: [subroute_id], references: [id])
+  stop_id        String    @db.Uuid
+  stop           Stop      @relation(fields: [stop_id], references: [id])
+  sequence       Int
+  is_active      Boolean   @default(true)
+  inactive_at    DateTime?
+  tdx_updated_at DateTime?
+  created_at     DateTime  @default(now())
+  updated_at     DateTime  @updatedAt
+
+  @@unique([subroute_id, stop_id, sequence])
+  @@index([stop_id])
+  @@index([subroute_id, sequence])
+  @@map("route_stop")
+}

--- a/apps/api/prisma/models/route-stop.prisma
+++ b/apps/api/prisma/models/route-stop.prisma
@@ -11,7 +11,7 @@ model RouteStop {
   created_at     DateTime  @default(now())
   updated_at     DateTime  @updatedAt
 
-  @@unique([subroute_id, stop_id, sequence])
+  @@unique([subroute_id, sequence])
   @@index([stop_id])
   @@index([subroute_id, sequence])
   @@map("route_stop")

--- a/apps/api/prisma/models/route.prisma
+++ b/apps/api/prisma/models/route.prisma
@@ -21,6 +21,7 @@ model Route {
   created_at         DateTime     @default(now())
   updated_at         DateTime     @updatedAt
   subroutes          SubRoute[]
+  route_operators    RouteOperator[]
 
   @@unique([city, tdx_route_id])
   @@map("route")

--- a/apps/api/prisma/models/route.prisma
+++ b/apps/api/prisma/models/route.prisma
@@ -1,27 +1,28 @@
 model Route {
-  id                 String       @id @default(uuid()) @db.Uuid
-  uuid               String       @unique @db.VarChar(64)
-  tdx_route_id       String       @db.VarChar(64)
-  city               CityNameType
-  name_zh_tw         String       @db.VarChar(100)
-  name_en            String?      @db.VarChar(100)
-  name_ja            String?      @db.VarChar(100)
-  name_ko            String?      @db.VarChar(100)
-  departure_zh_tw    String       @db.VarChar(100)
-  departure_en       String?      @db.VarChar(100)
-  departure_ja       String?      @db.VarChar(100)
-  departure_ko       String?      @db.VarChar(100)
-  destination_zh_tw  String       @db.VarChar(100)
-  destination_en     String?      @db.VarChar(100)
-  destination_ja     String?      @db.VarChar(100)
-  destination_ko     String?      @db.VarChar(100)
-  is_active          Boolean      @default(true)
-  inactive_at        DateTime?
-  tdx_updated_at     DateTime?
-  created_at         DateTime     @default(now())
-  updated_at         DateTime     @updatedAt
-  subroutes          SubRoute[]
-  route_operators    RouteOperator[]
+  id                   String              @id @default(uuid()) @db.Uuid
+  uuid                 String              @unique @db.VarChar(64)
+  tdx_route_id         String              @db.VarChar(64)
+  city                 CityNameType
+  name_zh_tw           String              @db.VarChar(100)
+  name_en              String?             @db.VarChar(100)
+  name_ja              String?             @db.VarChar(100)
+  name_ko              String?             @db.VarChar(100)
+  departure_zh_tw      String              @db.VarChar(100)
+  departure_en         String?             @db.VarChar(100)
+  departure_ja         String?             @db.VarChar(100)
+  departure_ko         String?             @db.VarChar(100)
+  destination_zh_tw    String              @db.VarChar(100)
+  destination_en       String?             @db.VarChar(100)
+  destination_ja       String?             @db.VarChar(100)
+  destination_ko       String?             @db.VarChar(100)
+  is_active            Boolean             @default(true)
+  inactive_at          DateTime?
+  tdx_updated_at       DateTime?
+  created_at           DateTime            @default(now())
+  updated_at           DateTime            @updatedAt
+  subroutes            SubRoute[]
+  route_operators      RouteOperator[]
+  favorite_route_stops FavoriteRouteStop[]
 
   @@unique([city, tdx_route_id])
   @@map("route")

--- a/apps/api/prisma/models/stop.prisma
+++ b/apps/api/prisma/models/stop.prisma
@@ -1,24 +1,26 @@
 model Stop {
-  id             String       @id @default(uuid()) @db.Uuid
-  uuid           String       @unique @db.VarChar(64)
-  tdx_stop_id    String       @db.VarChar(64)
-  station_id     String?      @db.Uuid
-  station        Station?     @relation(fields: [station_id], references: [id])
-  city           CityNameType
-  name_zh_tw     String       @db.VarChar(100)
-  name_en        String?      @db.VarChar(100)
-  name_ja        String?      @db.VarChar(100)
-  name_ko        String?      @db.VarChar(100)
-  address_zh_tw  String?      @db.VarChar(255)
-  address_en     String?      @db.VarChar(255)
-  latitude       Float
-  longitude      Float
-  bearing        BearingType?
-  is_active      Boolean      @default(true)
-  inactive_at    DateTime?
-  tdx_updated_at DateTime?
-  created_at     DateTime     @default(now())
-  updated_at     DateTime     @updatedAt
+  id                   String              @id @default(uuid()) @db.Uuid
+  uuid                 String              @unique @db.VarChar(64)
+  tdx_stop_id          String              @db.VarChar(64)
+  station_id           String?             @db.Uuid
+  station              Station?            @relation(fields: [station_id], references: [id])
+  city                 CityNameType
+  name_zh_tw           String              @db.VarChar(100)
+  name_en              String?             @db.VarChar(100)
+  name_ja              String?             @db.VarChar(100)
+  name_ko              String?             @db.VarChar(100)
+  address_zh_tw        String?             @db.VarChar(255)
+  address_en           String?             @db.VarChar(255)
+  latitude             Float
+  longitude            Float
+  bearing              BearingType?
+  is_active            Boolean             @default(true)
+  inactive_at          DateTime?
+  tdx_updated_at       DateTime?
+  created_at           DateTime            @default(now())
+  updated_at           DateTime            @updatedAt
+  route_stops          RouteStop[]
+  favorite_route_stops FavoriteRouteStop[]
 
   @@unique([city, tdx_stop_id])
   @@index([station_id])

--- a/apps/api/prisma/models/sub-route.prisma
+++ b/apps/api/prisma/models/sub-route.prisma
@@ -24,6 +24,7 @@ model SubRoute {
   tdx_updated_at     DateTime?
   created_at         DateTime      @default(now())
   updated_at         DateTime      @updatedAt
+  route_shape        RouteShape?
 
   @@unique([route_id, direction, tdx_subroute_id])
   @@index([route_id])

--- a/apps/api/prisma/models/sub-route.prisma
+++ b/apps/api/prisma/models/sub-route.prisma
@@ -1,30 +1,32 @@
 model SubRoute {
-  id                 String        @id @default(uuid()) @db.Uuid
-  uuid               String        @unique @db.VarChar(64)
-  tdx_subroute_id    String        @db.VarChar(64)
-  route_id           String        @db.Uuid
-  route              Route         @relation(fields: [route_id], references: [id])
-  direction          DirectionType
-  name_zh_tw         String        @db.VarChar(100)
-  name_en            String?       @db.VarChar(100)
-  name_ja            String?       @db.VarChar(100)
-  name_ko            String?       @db.VarChar(100)
-  departure_zh_tw    String        @db.VarChar(100)
-  departure_en       String?       @db.VarChar(100)
-  departure_ja       String?       @db.VarChar(100)
-  departure_ko       String?       @db.VarChar(100)
-  destination_zh_tw  String        @db.VarChar(100)
-  destination_en     String?       @db.VarChar(100)
-  destination_ja     String?       @db.VarChar(100)
-  destination_ko     String?       @db.VarChar(100)
-  first_bus_time     String?       @db.VarChar(10)
-  last_bus_time      String?       @db.VarChar(10)
-  is_active          Boolean       @default(true)
-  inactive_at        DateTime?
-  tdx_updated_at     DateTime?
-  created_at         DateTime      @default(now())
-  updated_at         DateTime      @updatedAt
-  route_shape        RouteShape?
+  id                   String              @id @default(uuid()) @db.Uuid
+  uuid                 String              @unique @db.VarChar(64)
+  tdx_subroute_id      String              @db.VarChar(64)
+  route_id             String              @db.Uuid
+  route                Route               @relation(fields: [route_id], references: [id])
+  direction            DirectionType
+  name_zh_tw           String              @db.VarChar(100)
+  name_en              String?             @db.VarChar(100)
+  name_ja              String?             @db.VarChar(100)
+  name_ko              String?             @db.VarChar(100)
+  departure_zh_tw      String              @db.VarChar(100)
+  departure_en         String?             @db.VarChar(100)
+  departure_ja         String?             @db.VarChar(100)
+  departure_ko         String?             @db.VarChar(100)
+  destination_zh_tw    String              @db.VarChar(100)
+  destination_en       String?             @db.VarChar(100)
+  destination_ja       String?             @db.VarChar(100)
+  destination_ko       String?             @db.VarChar(100)
+  first_bus_time       String?             @db.VarChar(10)
+  last_bus_time        String?             @db.VarChar(10)
+  is_active            Boolean             @default(true)
+  inactive_at          DateTime?
+  tdx_updated_at       DateTime?
+  created_at           DateTime            @default(now())
+  updated_at           DateTime            @updatedAt
+  route_shape          RouteShape?
+  route_stops          RouteStop[]
+  favorite_route_stops FavoriteRouteStop[]
 
   @@unique([route_id, direction, tdx_subroute_id])
   @@index([route_id])

--- a/apps/api/prisma/models/sync-error.prisma
+++ b/apps/api/prisma/models/sync-error.prisma
@@ -1,0 +1,14 @@
+model SyncError {
+  id          String           @id @default(uuid()) @db.Uuid
+  sync_run_id String           @db.Uuid
+  sync_run    SyncRun          @relation(fields: [sync_run_id], references: [id])
+  resource    SyncResourceType
+  tdx_uuid    String?          @db.VarChar(64)
+  message     String           @db.Text
+  payload     Json?
+  created_at  DateTime         @default(now())
+
+  @@index([sync_run_id])
+  @@index([resource])
+  @@map("sync_error")
+}

--- a/apps/api/prisma/models/sync-run.prisma
+++ b/apps/api/prisma/models/sync-run.prisma
@@ -1,0 +1,19 @@
+model SyncRun {
+  id                  String         @id @default(uuid()) @db.Uuid
+  resource            SyncResourceType
+  status              SyncStatusType @default(QUEUED)
+  started_at          DateTime?
+  finished_at         DateTime?
+  records_read        Int            @default(0)
+  records_created     Int            @default(0)
+  records_updated     Int            @default(0)
+  records_deactivated Int            @default(0)
+  error_message       String?        @db.Text
+  created_at          DateTime       @default(now())
+  updated_at          DateTime       @updatedAt
+  errors              SyncError[]
+
+  @@index([resource, status])
+  @@index([created_at])
+  @@map("sync_run")
+}

--- a/apps/api/prisma/models/user-setting.prisma
+++ b/apps/api/prisma/models/user-setting.prisma
@@ -1,0 +1,11 @@
+model UserSetting {
+  id                           String        @id @default(uuid()) @db.Uuid
+  user_id                      String        @unique @db.Uuid
+  user                         User          @relation(fields: [user_id], references: [id])
+  locale                       AppLocaleType @default(ZH_TW)
+  is_google_analytics_enabled  Boolean       @default(true)
+  created_at                   DateTime      @default(now())
+  updated_at                   DateTime      @updatedAt
+
+  @@map("user_setting")
+}

--- a/apps/api/prisma/models/user.prisma
+++ b/apps/api/prisma/models/user.prisma
@@ -1,0 +1,13 @@
+model User {
+  id                   String              @id @default(uuid()) @db.Uuid
+  uuid                 String              @unique @db.VarChar(64)
+  name                 String              @db.VarChar(100)
+  email                String              @unique @db.VarChar(255)
+  password_hash        String              @db.VarChar(255)
+  created_at           DateTime            @default(now())
+  updated_at           DateTime            @updatedAt
+  favorite_route_stops FavoriteRouteStop[]
+  setting              UserSetting?
+
+  @@map("user")
+}

--- a/apps/api/prisma/models/vehicle.prisma
+++ b/apps/api/prisma/models/vehicle.prisma
@@ -1,0 +1,11 @@
+model Vehicle {
+  id           String       @id @default(uuid()) @db.Uuid
+  uuid         String       @unique @db.VarChar(64)
+  plate_number String       @db.VarChar(50)
+  city         CityNameType
+  created_at   DateTime     @default(now())
+  updated_at   DateTime     @updatedAt
+
+  @@unique([city, plate_number])
+  @@map("vehicle")
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -23,5 +23,6 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
+  "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts", "test/**/*.ts"]
 }

--- a/apps/tdx-proxy/src/index.ts
+++ b/apps/tdx-proxy/src/index.ts
@@ -139,23 +139,26 @@ function logProxyRequest({
   durationMs,
   path,
   retriedAfterUnauthorized,
-  search,
-  status
+  searchLength,
+  status,
+  urlLength
 }: {
   durationMs: number
   path: string
   retriedAfterUnauthorized: boolean
-  search: string
+  searchLength: number
   status: number
+  urlLength: number
 }) {
   console.log(JSON.stringify({
     type: 'tdx-proxy-request',
     timestamp: new Date().toISOString(),
     path,
-    search,
     status,
     durationMs,
     requestCount: 1,
+    searchLength,
+    urlLength,
     retriedAfterUnauthorized
   }))
 }
@@ -231,8 +234,9 @@ export default {
         durationMs,
         path: requestUrl.pathname.replace(/^\/api\/tdx/, ''),
         retriedAfterUnauthorized,
-        search: requestUrl.search,
-        status: upstreamResponse.status
+        searchLength: requestUrl.search.length,
+        status: upstreamResponse.status,
+        urlLength: requestUrl.href.length
       })
 
       return new Response(upstreamResponse.body, {
@@ -246,7 +250,8 @@ export default {
         type: 'tdx-proxy-error',
         timestamp: new Date().toISOString(),
         path: requestUrl.pathname.replace(/^\/api\/tdx/, ''),
-        search: requestUrl.search,
+        searchLength: requestUrl.search.length,
+        urlLength: requestUrl.href.length,
         message: error instanceof Error ? error.message : 'Unknown error'
       }))
 

--- a/apps/tdx-proxy/src/index.ts
+++ b/apps/tdx-proxy/src/index.ts
@@ -156,7 +156,7 @@ function logProxyRequest({
     path,
     status,
     durationMs,
-    requestCount: 1,
+    requestCount: retriedAfterUnauthorized ? 2 : 1,
     searchLength,
     urlLength,
     retriedAfterUnauthorized

--- a/packages/shared/src/enums/AppLocaleType.ts
+++ b/packages/shared/src/enums/AppLocaleType.ts
@@ -1,4 +1,6 @@
 export enum AppLocaleType {
   ZH_TW = 'zh-TW',
   EN = 'en',
+  JA = 'ja',
+  KO = 'ko',
 }

--- a/packages/shared/src/enums/AppLocaleType.ts
+++ b/packages/shared/src/enums/AppLocaleType.ts
@@ -1,6 +1,4 @@
 export enum AppLocaleType {
   ZH_TW = 'zh-TW',
   EN = 'en',
-  JA = 'ja',
-  KO = 'ko',
 }


### PR DESCRIPTION
## Related

- Part of #31
- Follows #40

## Summary

Extend the API Prisma database schema beyond the initial core bus base data.

This PR adds the next layer of planned backend data models, including route detail joins, route shapes, operators, sync tracking, user settings, favorite route stops, and a placeholder for vehicle snapshot data. It also updates API quality scripts so Prisma schema formatting and validation are part of the API workspace workflow.

## What Changed

- Added Prisma schema files for route detail data:
  - RouteStop
  - RouteShape
  - Operator
  - RouteOperator
- Added sync tracking schema:
  - SyncRun
  - SyncError
  - SyncResourceType
  - SyncStatusType
- Added user-related schema:
  - User
  - UserSetting
  - FavoriteRouteStop
  - AppLocaleType
- Added Vehicle as a first schema placeholder for realtime-related data.
- Added RouteShapeSource to distinguish whether a route path comes from TDX shape data, geometry data, or stop positions.
- Added `ja` and `ko` to shared app locale values for future locale support without changing the frontend settings UI.
- Updated API scripts:
  - `format` now includes Prisma formatting.
  - `lint` now includes Prisma validation.
  - `test` now runs unit and e2e scripts.
- Updated API TypeScript config to scope typecheck to API source files.
- Added TDX proxy URL/query length logging to help diagnose long-query failures without logging full query strings.
- Updated `database-plan.md` with follow-up notes around Prisma validation, formatting, CI, and Husky.

## Validation

- [x] Husky pre-commit checks ran during commits
- [x] `@bus/tdx-proxy` staged check passed during the latest commit

Full API/web checks were not rerun while preparing this PR content.

## Scope Notes

This PR extends the Prisma schema plan only.

Intentionally left for follow-up PRs:

- Prisma migrations
- database seed data
- actual TDX sync implementation
- API reads from the database
- Prisma client/service integration in NestJS
- realtime cache/storage strategy
- frontend migration from TDX proxy calls to backend BFF endpoints

## Reviewer Notes

Main files to review:

- `apps/api/prisma/enums/*`
- `apps/api/prisma/models/*`
- `apps/api/docs/database-plan.md`
- `apps/api/package.json`
- `packages/shared/src/enums/AppLocaleType.ts`
- `apps/tdx-proxy/src/index.ts`

Important design choices:

- `route_operator` is modeled as a join table so the schema can support routes with one or more operators.
- Route shape storage keeps source information, but the backend should eventually return a normalized path to the frontend.
- Sync tracking is modeled separately from the synced bus base data.
- Favorite records can be hard-deleted, while referenced bus entities can later use status fields to indicate deprecated upstream data.
- TDX proxy logging records URL/query lengths only, not the full query string.