### PR TITLE
fix(api): stabilize stop sync import

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -58,6 +58,9 @@ Stop sync is much larger than route sync. A single major city can include tens o
 
 Progress logs are grouped by stage and report roughly ten times per stage so large imports remain visible without flooding logs.
 
+For known sync failure modes and TDX data-shape notes, see
+[Sync Troubleshooting](./docs/sync-troubleshooting.md).
+
 ## API Documentation
 
 Scalar renders the generated OpenAPI document:

--- a/apps/api/docs/README.zh-TW.md
+++ b/apps/api/docs/README.zh-TW.md
@@ -58,6 +58,9 @@ Stop sync 的資料量比 route sync 大很多。單一主要城市就可能包�
 
 進度 log 會依階段顯示，並且每個階段大約回報十次，讓大量匯入時看得到進度，但不會把 logs 洗得太長。
 
+已知的 sync 失敗情境與 TDX 資料形狀筆記，放在
+[Sync Troubleshooting](./sync-troubleshooting.md)。
+
 ## API 文件
 
 Scalar 會渲染產生出來的 OpenAPI 文件：

--- a/apps/api/docs/database-plan.md
+++ b/apps/api/docs/database-plan.md
@@ -906,6 +906,45 @@ Keep the first version read-only apart from explicit sync actions. Do not add bu
 
 Use Prisma Studio and application logs for local inspection until the manager provides enough value to justify its own application and deployment.
 
+## Current Storage Snapshot
+
+Observed after one full route sync and one full stop sync on 2026-07-10.
+
+Database size:
+
+- total database size: about 148 MB
+- Prisma Free storage limit reference: 512 MiB
+
+Largest tables:
+
+| Table | Estimated rows | Total size | Table data | Indexes | Notes |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `route_stop` | 233,698 | 65 MiB | 25 MiB | 41 MiB | Largest table; indexes are larger than row data. |
+| `stop` | 134,869 | 46 MiB | 27 MiB | 19 MiB | Main stop sync table. |
+| `station` | 49,874 | 14 MiB | 7.71 MiB | 6.30 MiB | Station data is not available for every city. |
+| `route_shape` | 6,771 | 8.05 MiB | 7.38 MiB | 624 KiB | Shared by route detail rendering and stop-position fallback shapes. |
+| `subroute` | 6,798 | 2.70 MiB | 1.43 MiB | 1.23 MiB | Route direction and variant rows. |
+| `station_group` | 6,580 | 1.88 MiB | 1000 KiB | 888 KiB | Optional because TDX support differs by city. |
+| `route` | 3,034 | 1000 KiB | 560 KiB | 400 KiB | Route list data. |
+| `route_operator` | 3,296 | 520 KiB | 200 KiB | 288 KiB | Route/operator join rows. |
+| `operator` | 153 | 96 KiB | 24 KiB | 32 KiB | Operator reference rows. |
+
+Approximate grouping:
+
+- route-related base tables excluding `route_shape`: about 4.3 MiB
+- stop-related base tables excluding `route_shape`: about 127 MiB
+- shared shape table: about 8.05 MiB
+- sync bookkeeping tables: currently small, less than 1 MiB combined
+
+Empty or mostly unused tables are expected at this stage:
+
+- `sync_error`: planned for partial per-record parse/save errors. Current failed syncs store the main error on `sync_run.error_message`.
+- `user`, `user_setting`, and `favorite_route_stop`: planned for auth, settings, and favorite sync later.
+- `vehicle`: planned for realtime-related work later.
+
+These tables still take a small amount of space because PostgreSQL stores table
+and index metadata even when there are no rows.
+
 ## Completed Foundation
 
 - Sync API contract and queued `sync_run` creation
@@ -914,14 +953,15 @@ Use Prisma Studio and application logs for local inspection until the manager pr
 - Background route sync with all-city checkpoints and stale-run recovery
 - Route, subroute, operator, and route-operator persistence
 - Soft deactivation and reactivation of route base data
-- Initial stop sync foundation for station groups, stations, stops, route stops, and fallback route shapes
+- Stop sync for station groups, stations, stops, route stops, and fallback route shapes
+- Full real-data stop sync validation across Taiwan
 
 ## Plan Order
 
-1. Validate stop sync with real data in small city batches and tune database usage.
-2. Read `GET /api/routes?area=...` from the database.
-3. Read `GET /api/routes/:uuid` from the database.
-4. Read `GET /api/stations?latitude=...&longitude=...` from the database.
+1. Read `GET /api/routes?area=...` from the database.
+2. Read `GET /api/routes/:uuid` from the database.
+3. Read `GET /api/stations?latitude=...&longitude=...` from the database.
+4. Continue monitoring database size after full sync runs.
 5. Deploy the API, run migrations safely, and protect admin operations.
 6. Decide where scheduled monthly sync jobs run after deployment is stable.
 7. Discuss realtime cache.

--- a/apps/api/docs/sync-troubleshooting.md
+++ b/apps/api/docs/sync-troubleshooting.md
@@ -1,0 +1,126 @@
+# Sync Troubleshooting
+
+This document records sync issues that were observed while importing TDX bus
+base data.
+
+## Stop Sync Fails With Query Parameter Limit
+
+Error example:
+
+```text
+The query parameter limit supported by your database is exceeded.
+```
+
+Cause:
+
+The first stop sync implementation used a large `notIn` filter to deactivate
+local rows that were missing from the latest TDX response.
+
+For large cities, the incoming stop UUID list can contain tens of thousands of
+values. Passing that list as one SQL query can exceed the database query
+parameter limit.
+
+Current handling:
+
+- Load currently active local UUIDs for the city.
+- Compare them with incoming TDX UUIDs in application code.
+- Deactivate missing rows with smaller batched `in` updates.
+
+This pattern is used for:
+
+- station groups
+- stations
+- stops
+
+## Stop Sync Fails With `ON CONFLICT DO UPDATE`
+
+Error example:
+
+```text
+ON CONFLICT DO UPDATE command cannot affect row a second time
+```
+
+Cause:
+
+PostgreSQL can handle rows that conflict with existing database rows, but one
+bulk `INSERT ... ON CONFLICT DO UPDATE` statement cannot update the same target
+row more than once.
+
+This can happen when the TDX response contains duplicate records for the same
+database conflict key inside one bulk batch.
+
+Current handling:
+
+`StopBulkWriterService` deduplicates records before running raw SQL upserts.
+The latest record in the same batch wins.
+
+Conflict keys:
+
+| Sync stage      | Conflict key               |
+| --------------- | -------------------------- |
+| station groups  | `uuid`                     |
+| stations        | `uuid`                     |
+| stops           | `uuid`                     |
+| route stops     | `subroute_id` + `sequence` |
+| route shapes    | `subroute_id`              |
+
+The writer logs a warning when duplicate records are dropped. The warning keeps
+only a small sample so large syncs do not flood logs.
+
+## TDX StopOfRoute Can Duplicate One Subroute By Operator
+
+Observed TDX example:
+
+```text
+GET /v2/Bus/StopOfRoute/City/YilanCounty
+```
+
+Filtered by:
+
+```text
+SubRouteUID eq 'ILA011201'
+```
+
+TDX returned two records with the same route and subroute identity:
+
+```text
+RouteUID: ILA0112
+RouteName: 112
+SubRouteUID: ILA011201
+Direction: 0
+City: YilanCounty
+```
+
+The difference was the operator:
+
+| OperatorID | OperatorName |
+| ---------- | ------------ |
+| `35`       | 葛瑪蘭客運   |
+| `39`       | 首都客運     |
+
+Both records contained the same stop sequence. For example, both started with:
+
+```text
+StopUID: ILA296014
+StopName: 礁溪轉運站
+StopSequence: 1
+StationID: 133177
+```
+
+The API mapper converts `SubRouteUID + Direction` into the local subroute UUID:
+
+```text
+ILA011201 + 0 -> ILA011201-0
+```
+
+After flattening `Stops[]`, the two TDX records become duplicate local route
+stops:
+
+```text
+subroute_uuid: ILA011201-0
+sequence: 1
+```
+
+The route stop table intentionally stores only one row per subroute sequence, so
+the duplicate TDX rows are deduplicated before writing to the database.
+

--- a/apps/api/docs/sync-troubleshooting.md
+++ b/apps/api/docs/sync-troubleshooting.md
@@ -64,8 +64,40 @@ Conflict keys:
 | route stops     | `subroute_id` + `sequence` |
 | route shapes    | `subroute_id`              |
 
-The writer logs a warning when duplicate records are dropped. The warning keeps
-only a small sample so large syncs do not flood logs.
+Duplicate rows are dropped silently for now. If this becomes hard to debug, add
+targeted logging with small samples instead of logging every duplicate row.
+
+## TDX Endpoint City Support Differs By Resource
+
+Error example:
+
+```text
+TDX request failed: 400 /api/basic/v2/Bus/Station/City/LienchiangCounty:
+{"Message":"City: 'LienchiangCounty' is not accepted but ..."}
+```
+
+Cause:
+
+TDX bus endpoints do not all support the same city list. A city can be valid for
+one resource but rejected by another resource.
+
+Observed examples:
+
+- `StationGroup/City` does not support every city. Taipei and NewTaipei are
+  skipped for station groups during stop sync.
+- `Station/City` does not support LienchiangCounty. Stop sync skips station
+  import for LienchiangCounty and continues with stops, route stops, and route
+  shapes.
+
+Current handling:
+
+- Keep the unsupported-city logic close to the sync orchestration code.
+- Treat unsupported optional resources as a skip, not a failed sync.
+- Keep required resources strict. For example, an empty stop response still
+  fails fast because stop sync cannot be useful without stops.
+
+When adding another TDX resource, check the Swagger accepted city list before
+assuming all 22 cities are supported.
 
 ## TDX StopOfRoute Can Duplicate One Subroute By Operator
 
@@ -123,4 +155,3 @@ sequence: 1
 
 The route stop table intentionally stores only one row per subroute sequence, so
 the duplicate TDX rows are deduplicated before writing to the database.
-

--- a/apps/api/src/sync/stop-bulk-writer.service.spec.ts
+++ b/apps/api/src/sync/stop-bulk-writer.service.spec.ts
@@ -67,6 +67,42 @@ function createStationGroup(
   }
 }
 
+function createStation(index: number): StopSyncRecords['stations'][number] {
+  return {
+    uuid: `station-${index}`,
+    tdx_station_id: `station-id-${index}`,
+    station_group_uuid: null,
+    city: PrismaCityNameType.TAIPEI,
+    name_zh_tw: `站位 ${index}`,
+    name_en: `Station ${index}`,
+    name_ja: null,
+    name_ko: null,
+    address_zh_tw: null,
+    latitude: 25 + index / 1000,
+    longitude: 121 + index / 1000,
+    bearing: null,
+    tdx_updated_at: null,
+  }
+}
+
+function createStop(index: number): StopSyncRecords['stops'][number] {
+  return {
+    uuid: `stop-${index}`,
+    tdx_stop_id: `stop-id-${index}`,
+    station_tdx_id: null,
+    city: PrismaCityNameType.TAIPEI,
+    name_zh_tw: `站牌 ${index}`,
+    name_en: `Stop ${index}`,
+    name_ja: null,
+    name_ko: null,
+    address_zh_tw: null,
+    latitude: 25 + index / 1000,
+    longitude: 121 + index / 1000,
+    bearing: null,
+    tdx_updated_at: null,
+  }
+}
+
 describe('StopBulkWriterService', () => {
   it('chunks station group upserts before writing raw SQL', async () => {
     const { prismaService, rawQueryCalls } = createPrismaMock()
@@ -91,6 +127,84 @@ describe('StopBulkWriterService', () => {
     expect(renderRawQuery(rawQueryCalls[0])).toContain(
       'ON CONFLICT ("uuid") DO UPDATE SET',
     )
+  })
+
+  it('deduplicates station groups by uuid before writing raw SQL', async () => {
+    const { prismaService, rawQueryCalls } = createPrismaMock()
+    const service = new StopBulkWriterService(prismaService)
+    const firstRecord = createStationGroup(1)
+    const latestRecord = {
+      ...createStationGroup(2),
+      uuid: firstRecord.uuid,
+      tdx_station_group_id: 'latest-station-group-id',
+      name_zh_tw: '最新站群',
+    }
+
+    await service.upsertStationGroups([firstRecord, latestRecord], () =>
+      Promise.resolve(),
+    )
+
+    const nestedValues = getNestedRawValues(rawQueryCalls[0])
+
+    expect(rawQueryCalls).toHaveLength(1)
+    expect(nestedValues).toContain('latest-station-group-id')
+    expect(nestedValues).toContain('最新站群')
+    expect(nestedValues).not.toContain(firstRecord.tdx_station_group_id)
+    expect(nestedValues).not.toContain(firstRecord.name_zh_tw)
+  })
+
+  it('deduplicates stations by uuid before writing raw SQL', async () => {
+    const { prismaService, rawQueryCalls } = createPrismaMock()
+    const service = new StopBulkWriterService(prismaService)
+    const firstRecord = createStation(1)
+    const latestRecord = {
+      ...createStation(2),
+      uuid: firstRecord.uuid,
+      tdx_station_id: 'latest-station-id',
+      name_zh_tw: '最新站位',
+    }
+
+    await service.upsertStations(
+      [firstRecord, latestRecord],
+      new Map(),
+      new Map(),
+      () => Promise.resolve(),
+    )
+
+    const nestedValues = getNestedRawValues(rawQueryCalls[0])
+
+    expect(rawQueryCalls).toHaveLength(1)
+    expect(nestedValues).toContain('latest-station-id')
+    expect(nestedValues).toContain('最新站位')
+    expect(nestedValues).not.toContain(firstRecord.tdx_station_id)
+    expect(nestedValues).not.toContain(firstRecord.name_zh_tw)
+  })
+
+  it('deduplicates stops by uuid before writing raw SQL', async () => {
+    const { prismaService, rawQueryCalls } = createPrismaMock()
+    const service = new StopBulkWriterService(prismaService)
+    const firstRecord = createStop(1)
+    const latestRecord = {
+      ...createStop(2),
+      uuid: firstRecord.uuid,
+      tdx_stop_id: 'latest-stop-id',
+      name_zh_tw: '最新站牌',
+    }
+
+    await service.upsertStops(
+      [firstRecord, latestRecord],
+      new Map(),
+      new Map(),
+      () => Promise.resolve(),
+    )
+
+    const nestedValues = getNestedRawValues(rawQueryCalls[0])
+
+    expect(rawQueryCalls).toHaveLength(1)
+    expect(nestedValues).toContain('latest-stop-id')
+    expect(nestedValues).toContain('最新站牌')
+    expect(nestedValues).not.toContain(firstRecord.tdx_stop_id)
+    expect(nestedValues).not.toContain(firstRecord.name_zh_tw)
   })
 
   it('writes route stops only when subroute and stop ids are available', async () => {

--- a/apps/api/src/sync/stop-bulk-writer.service.spec.ts
+++ b/apps/api/src/sync/stop-bulk-writer.service.spec.ts
@@ -35,6 +35,21 @@ function renderRawQuery(call: RawQueryCall): string {
     .trim()
 }
 
+function getNestedRawValues(call: RawQueryCall): unknown[] {
+  return call.values.flatMap((value) => {
+    if (
+      value &&
+      typeof value === 'object' &&
+      'values' in value &&
+      Array.isArray((value as { values: unknown[] }).values)
+    ) {
+      return (value as { values: unknown[] }).values
+    }
+
+    return [value]
+  })
+}
+
 function createStationGroup(
   index: number,
 ): StopSyncRecords['stationGroups'][number] {
@@ -122,6 +137,44 @@ describe('StopBulkWriterService', () => {
     )
   })
 
+  it('deduplicates route stops by subroute and sequence before writing raw SQL', async () => {
+    const { prismaService, rawQueryCalls } = createPrismaMock()
+    const service = new StopBulkWriterService(prismaService)
+    const incomingKeys = new Set<string>()
+    const routeStops: StopSyncRecords['routeStops'] = [
+      {
+        subroute_uuid: 'subroute-1',
+        stop_uuid: 'stop-1',
+        sequence: 1,
+        tdx_updated_at: null,
+      },
+      {
+        subroute_uuid: 'subroute-1',
+        stop_uuid: 'stop-2',
+        sequence: 1,
+        tdx_updated_at: null,
+      },
+    ]
+
+    await service.upsertRouteStops(
+      routeStops,
+      new Map([['subroute-1', 'subroute-db-1']]),
+      new Map([
+        ['stop-1', 'stop-db-1'],
+        ['stop-2', 'stop-db-2'],
+      ]),
+      incomingKeys,
+      () => Promise.resolve(),
+    )
+
+    const nestedValues = getNestedRawValues(rawQueryCalls[0])
+
+    expect(incomingKeys).toEqual(new Set(['subroute-db-1:1']))
+    expect(rawQueryCalls).toHaveLength(1)
+    expect(nestedValues).toContain('stop-db-2')
+    expect(nestedValues).not.toContain('stop-db-1')
+  })
+
   it('preserves non-fallback route shapes when upserting fallback shapes', async () => {
     const { prismaService, rawQueryCalls } = createPrismaMock()
     const service = new StopBulkWriterService(prismaService)
@@ -145,5 +198,36 @@ describe('StopBulkWriterService', () => {
     expect(renderRawQuery(rawQueryCalls[0])).toContain(
       `WHERE "route_shape"."source" = 'stop_positions'::"RouteShapeSource"`,
     )
+  })
+
+  it('deduplicates route shapes by subroute before writing raw SQL', async () => {
+    const { prismaService, rawQueryCalls } = createPrismaMock()
+    const service = new StopBulkWriterService(prismaService)
+    const routeShapes: StopSyncRecords['routeShapes'] = [
+      {
+        subroute_uuid: 'subroute-1',
+        source: PrismaRouteShapeSource.STOP_POSITIONS,
+        path: [[121, 25]],
+        tdx_updated_at: null,
+      },
+      {
+        subroute_uuid: 'subroute-1',
+        source: PrismaRouteShapeSource.STOP_POSITIONS,
+        path: [[122, 26]],
+        tdx_updated_at: null,
+      },
+    ]
+
+    await service.upsertRouteShapes(
+      routeShapes,
+      new Map([['subroute-1', 'subroute-db-1']]),
+      () => Promise.resolve(),
+    )
+
+    const nestedValues = getNestedRawValues(rawQueryCalls[0])
+
+    expect(rawQueryCalls).toHaveLength(1)
+    expect(nestedValues).toContain(JSON.stringify([[122, 26]]))
+    expect(nestedValues).not.toContain(JSON.stringify([[121, 25]]))
   })
 })

--- a/apps/api/src/sync/stop-bulk-writer.service.ts
+++ b/apps/api/src/sync/stop-bulk-writer.service.ts
@@ -30,6 +30,8 @@ export class StopBulkWriterService {
     onBatch: (count: number) => Promise<void>,
   ): Promise<void> {
     for (const batch of this.chunk(stationGroups)) {
+      const records = this.uniqueBy(batch, (record) => record.uuid)
+
       await this.prismaService.$executeRaw`
         INSERT INTO "station_group" (
           "id",
@@ -48,7 +50,7 @@ export class StopBulkWriterService {
           "updated_at"
         )
         VALUES ${Prisma.join(
-          batch.map(
+          records.map(
             (record) => Prisma.sql`(
               ${randomUUID()}::uuid,
               ${record.uuid},
@@ -93,6 +95,8 @@ export class StopBulkWriterService {
     onBatch: (count: number) => Promise<void>,
   ): Promise<void> {
     for (const batch of this.chunk(stations)) {
+      const records = this.uniqueBy(batch, (record) => record.uuid)
+
       await this.prismaService.$executeRaw`
         INSERT INTO "station" (
           "id",
@@ -115,7 +119,7 @@ export class StopBulkWriterService {
           "updated_at"
         )
         VALUES ${Prisma.join(
-          batch.map((record) => {
+          records.map((record) => {
             const stationGroupId = record.station_group_uuid
               ? (stationGroupIds.get(record.station_group_uuid) ?? null)
               : null
@@ -176,6 +180,8 @@ export class StopBulkWriterService {
     onBatch: (count: number) => Promise<void>,
   ): Promise<void> {
     for (const batch of this.chunk(stops)) {
+      const records = this.uniqueBy(batch, (record) => record.uuid)
+
       await this.prismaService.$executeRaw`
         INSERT INTO "stop" (
           "id",
@@ -198,7 +204,7 @@ export class StopBulkWriterService {
           "updated_at"
         )
         VALUES ${Prisma.join(
-          batch.map((record) => {
+          records.map((record) => {
             const stationId = record.station_tdx_id
               ? (stationIds.get(record.station_tdx_id) ?? null)
               : null
@@ -260,23 +266,34 @@ export class StopBulkWriterService {
     onBatch: (count: number) => Promise<void>,
   ): Promise<void> {
     for (const batch of this.chunk(routeStops)) {
-      const values = batch.flatMap((record) => {
+      const valueByKey = new Map<
+        string,
+        {
+          subrouteId: string
+          stopId: string
+          sequence: number
+          tdxUpdatedAt: Date | null
+        }
+      >()
+
+      for (const record of batch) {
         const subrouteId = subrouteIds.get(record.subroute_uuid)
         const stopId = stopIds.get(record.stop_uuid)
 
-        if (!subrouteId || !stopId) return []
+        if (!subrouteId || !stopId) continue
 
-        incomingKeys.add(`${subrouteId}:${record.sequence}`)
+        const key = `${subrouteId}:${record.sequence}`
 
-        return [
-          {
-            subrouteId,
-            stopId,
-            sequence: record.sequence,
-            tdxUpdatedAt: record.tdx_updated_at,
-          },
-        ]
-      })
+        incomingKeys.add(key)
+        valueByKey.set(key, {
+          subrouteId,
+          stopId,
+          sequence: record.sequence,
+          tdxUpdatedAt: record.tdx_updated_at,
+        })
+      }
+
+      const values = [...valueByKey.values()]
 
       if (values.length > 0) {
         await this.prismaService.$executeRaw`
@@ -323,20 +340,30 @@ export class StopBulkWriterService {
     onBatch: (count: number) => Promise<void>,
   ): Promise<void> {
     for (const batch of this.chunk(routeShapes)) {
-      const values = batch.flatMap((record) => {
+      const valueByKey = new Map<
+        string,
+        {
+          subrouteId: string
+          source: PrismaRouteShapeSource
+          path: Array<[number, number]>
+          tdxUpdatedAt: Date | null
+        }
+      >()
+
+      for (const record of batch) {
         const subrouteId = subrouteIds.get(record.subroute_uuid)
 
-        if (!subrouteId) return []
+        if (!subrouteId) continue
 
-        return [
-          {
-            subrouteId,
-            source: record.source,
-            path: record.path,
-            tdxUpdatedAt: record.tdx_updated_at,
-          },
-        ]
-      })
+        valueByKey.set(subrouteId, {
+          subrouteId,
+          source: record.source,
+          path: record.path,
+          tdxUpdatedAt: record.tdx_updated_at,
+        })
+      }
+
+      const values = [...valueByKey.values()]
 
       if (values.length > 0) {
         await this.prismaService.$executeRaw`
@@ -397,6 +424,12 @@ export class StopBulkWriterService {
     }
 
     return chunks
+  }
+
+  private uniqueBy<T>(records: T[], getKey: (record: T) => string): T[] {
+    return [
+      ...new Map(records.map((record) => [getKey(record), record])).values(),
+    ]
   }
 
   private resolveAddress(

--- a/apps/api/src/sync/stop-persistence.service.spec.ts
+++ b/apps/api/src/sync/stop-persistence.service.spec.ts
@@ -192,6 +192,205 @@ describe('StopPersistenceService', () => {
     expect(stationUpdateCount).toBe(0)
   })
 
+  it('deactivates missing station groups in uuid batches without notIn filters', async () => {
+    const stationGroupUpdateManyArgs: Array<{
+      where: {
+        city: PrismaCityNameType
+        uuid: { in?: string[]; notIn?: string[] }
+        is_active: true
+      }
+    }> = []
+    const incomingStationGroup = {
+      uuid: 'TPE-station-group-1',
+      tdx_station_group_id: 'station-group-1',
+      city: PrismaCityNameType.TAIPEI,
+      name_zh_tw: '測試站群',
+      name_en: 'Test Station Group',
+      name_ja: null,
+      name_ko: null,
+      latitude: 25,
+      longitude: 121,
+      tdx_updated_at: null,
+    }
+    const activeStationGroups = [
+      { uuid: incomingStationGroup.uuid },
+      ...Array.from({ length: 501 }, (_, index) => ({
+        uuid: `TPE-old-station-group-${index}`,
+      })),
+    ]
+    const prismaService = {
+      stationGroup: {
+        findMany: () => Promise.resolve(activeStationGroups),
+        updateMany: (args: (typeof stationGroupUpdateManyArgs)[number]) => {
+          stationGroupUpdateManyArgs.push(args)
+
+          return Promise.resolve({ count: args.where.uuid.in?.length ?? 0 })
+        },
+      },
+      station: {
+        findMany: () => Promise.resolve([]),
+        updateMany: () => Promise.resolve({ count: 0 }),
+      },
+      stop: {
+        findMany: ({
+          where,
+          select,
+        }: {
+          where: { is_active?: true }
+          select: { uuid?: true; address_zh_tw?: true; address_en?: true }
+        }) => {
+          if (select.address_zh_tw || select.address_en || where.is_active) {
+            return Promise.resolve([
+              {
+                uuid: 'TPE-stop-1',
+                address_zh_tw: null,
+                address_en: null,
+              },
+            ])
+          }
+
+          return Promise.resolve([{ uuid: 'TPE-stop-1' }])
+        },
+        updateMany: () => Promise.resolve({ count: 0 }),
+      },
+    } as unknown as PrismaService
+    const stopBulkWriterService = {
+      upsertStationGroups: () => Promise.resolve(),
+      upsertStations: () => Promise.resolve(),
+      upsertStops: () => Promise.resolve(),
+      upsertRouteStops: () => Promise.resolve(),
+      upsertRouteShapes: () => Promise.resolve(),
+    } as unknown as StopBulkWriterService
+    const service = new StopPersistenceService(
+      prismaService,
+      stopBulkWriterService,
+    )
+    const records: StopSyncRecords = {
+      stationGroups: [incomingStationGroup],
+      stations: [],
+      stops: [stopRecord],
+      routeStops: [],
+      routeShapes: [],
+    }
+
+    await service.persistStops(records, {
+      city: CityNameType.TAIPEI,
+      syncStations: false,
+    })
+
+    expect(stationGroupUpdateManyArgs).toHaveLength(2)
+    expect(stationGroupUpdateManyArgs[0].where.uuid.in).toHaveLength(500)
+    expect(stationGroupUpdateManyArgs[0].where.uuid.notIn).toBeUndefined()
+    expect(stationGroupUpdateManyArgs[1].where.uuid.in).toHaveLength(1)
+    expect(stationGroupUpdateManyArgs[1].where.uuid.notIn).toBeUndefined()
+  })
+
+  it('deactivates missing stations in uuid batches without notIn filters', async () => {
+    const stationUpdateManyArgs: Array<{
+      where: {
+        city: PrismaCityNameType
+        uuid: { in?: string[]; notIn?: string[] }
+        is_active: true
+      }
+    }> = []
+    const activeStations = [
+      { uuid: stationRecord.uuid },
+      ...Array.from({ length: 501 }, (_, index) => ({
+        uuid: `TPE-old-station-${index}`,
+      })),
+    ]
+    const prismaService = {
+      stationGroup: {
+        findMany: () => Promise.resolve([]),
+        updateMany: () => Promise.resolve({ count: 0 }),
+      },
+      station: {
+        findMany: ({
+          where,
+          select,
+        }: {
+          where: { is_active?: true }
+          select: {
+            id?: true
+            tdx_station_id?: true
+            uuid?: true
+            address_zh_tw?: true
+            address_en?: true
+          }
+        }) => {
+          if (select.address_zh_tw || select.address_en) {
+            return Promise.resolve([
+              {
+                uuid: stationRecord.uuid,
+                address_zh_tw: null,
+                address_en: null,
+              },
+            ])
+          }
+
+          if (where.is_active) {
+            return Promise.resolve(activeStations)
+          }
+
+          return Promise.resolve([])
+        },
+        updateMany: (args: (typeof stationUpdateManyArgs)[number]) => {
+          stationUpdateManyArgs.push(args)
+
+          return Promise.resolve({ count: args.where.uuid.in?.length ?? 0 })
+        },
+      },
+      stop: {
+        findMany: ({
+          where,
+          select,
+        }: {
+          where: { is_active?: true }
+          select: { uuid?: true; address_zh_tw?: true; address_en?: true }
+        }) => {
+          if (select.address_zh_tw || select.address_en || where.is_active) {
+            return Promise.resolve([
+              {
+                uuid: 'TPE-stop-1',
+                address_zh_tw: null,
+                address_en: null,
+              },
+            ])
+          }
+
+          return Promise.resolve([{ uuid: 'TPE-stop-1' }])
+        },
+        updateMany: () => Promise.resolve({ count: 0 }),
+      },
+    } as unknown as PrismaService
+    const stopBulkWriterService = {
+      upsertStationGroups: () => Promise.resolve(),
+      upsertStations: () => Promise.resolve(),
+      upsertStops: () => Promise.resolve(),
+      upsertRouteStops: () => Promise.resolve(),
+      upsertRouteShapes: () => Promise.resolve(),
+    } as unknown as StopBulkWriterService
+    const service = new StopPersistenceService(
+      prismaService,
+      stopBulkWriterService,
+    )
+    const records: StopSyncRecords = {
+      stationGroups: [],
+      stations: [stationRecord],
+      stops: [stopRecord],
+      routeStops: [],
+      routeShapes: [],
+    }
+
+    await service.persistStops(records, { city: CityNameType.TAIPEI })
+
+    expect(stationUpdateManyArgs).toHaveLength(2)
+    expect(stationUpdateManyArgs[0].where.uuid.in).toHaveLength(500)
+    expect(stationUpdateManyArgs[0].where.uuid.notIn).toBeUndefined()
+    expect(stationUpdateManyArgs[1].where.uuid.in).toHaveLength(1)
+    expect(stationUpdateManyArgs[1].where.uuid.notIn).toBeUndefined()
+  })
+
   it('deactivates missing route stops in batches by subroute', async () => {
     const routeStopUpdateManyArgs: unknown[] = []
     const prismaService = {

--- a/apps/api/src/sync/stop-persistence.service.spec.ts
+++ b/apps/api/src/sync/stop-persistence.service.spec.ts
@@ -132,6 +132,66 @@ describe('StopPersistenceService', () => {
     expect(stationUpdateCount).toBe(0)
   })
 
+  it('allows empty stations when station sync is disabled', async () => {
+    let stationUpdateCount = 0
+    const prismaService = {
+      stationGroup: {
+        findMany: () => Promise.resolve([]),
+        updateMany: () => Promise.resolve({ count: 0 }),
+      },
+      station: {
+        findMany: () => Promise.resolve([]),
+        updateMany: () => {
+          stationUpdateCount += 1
+
+          return Promise.resolve({ count: 0 })
+        },
+      },
+      stop: {
+        findMany: () =>
+          Promise.resolve([
+            {
+              uuid: 'TPE-stop-1',
+              address_zh_tw: null,
+              address_en: null,
+            },
+          ]),
+        updateMany: () => Promise.resolve({ count: 0 }),
+      },
+    } as unknown as PrismaService
+    const stopBulkWriterService = {
+      upsertStationGroups: () => Promise.resolve(),
+      upsertStations: () => Promise.resolve(),
+      upsertStops: () => Promise.resolve(),
+      upsertRouteStops: () => Promise.resolve(),
+      upsertRouteShapes: () => Promise.resolve(),
+    } as unknown as StopBulkWriterService
+    const service = new StopPersistenceService(
+      prismaService,
+      stopBulkWriterService,
+    )
+    const records: StopSyncRecords = {
+      stationGroups: [],
+      stations: [],
+      stops: [stopRecord],
+      routeStops: [],
+      routeShapes: [],
+    }
+
+    await expect(
+      service.persistStops(records, {
+        city: CityNameType.TAIPEI,
+        syncStations: false,
+      }),
+    ).resolves.toEqual({
+      records_read: 1,
+      records_created: 0,
+      records_updated: 1,
+      records_deactivated: 0,
+    })
+    expect(stationUpdateCount).toBe(0)
+  })
+
   it('deactivates missing route stops in batches by subroute', async () => {
     const routeStopUpdateManyArgs: unknown[] = []
     const prismaService = {

--- a/apps/api/src/sync/stop-persistence.service.spec.ts
+++ b/apps/api/src/sync/stop-persistence.service.spec.ts
@@ -302,10 +302,14 @@ describe('StopPersistenceService', () => {
     }> = []
     const existingStops = [
       { uuid: 'TPE-stop-1' },
+      { uuid: 'TPE-inactive-stop-1' },
       ...Array.from({ length: 501 }, (_, index) => ({
         uuid: `TPE-old-stop-${index}`,
       })),
     ]
+    const activeStops = existingStops.filter(
+      (stop) => stop.uuid !== 'TPE-inactive-stop-1',
+    )
     const prismaService = {
       stationGroup: {
         findMany: () => Promise.resolve([]),
@@ -317,8 +321,10 @@ describe('StopPersistenceService', () => {
       },
       stop: {
         findMany: ({
+          where,
           select,
         }: {
+          where: { is_active?: true }
           select: { uuid?: true; address_zh_tw?: true; address_en?: true }
         }) => {
           if (select.address_zh_tw || select.address_en) {
@@ -329,6 +335,10 @@ describe('StopPersistenceService', () => {
                 address_en: null,
               },
             ])
+          }
+
+          if (where.is_active) {
+            return Promise.resolve(activeStops)
           }
 
           return Promise.resolve(existingStops)

--- a/apps/api/src/sync/stop-persistence.service.spec.ts
+++ b/apps/api/src/sync/stop-persistence.service.spec.ts
@@ -231,4 +231,83 @@ describe('StopPersistenceService', () => {
       }),
     ])
   })
+
+  it('deactivates missing stops in uuid batches without notIn filters', async () => {
+    const stopUpdateManyArgs: Array<{
+      where: {
+        city: PrismaCityNameType
+        uuid: { in?: string[]; notIn?: string[] }
+        is_active: true
+      }
+    }> = []
+    const existingStops = [
+      { uuid: 'TPE-stop-1' },
+      ...Array.from({ length: 501 }, (_, index) => ({
+        uuid: `TPE-old-stop-${index}`,
+      })),
+    ]
+    const prismaService = {
+      stationGroup: {
+        findMany: () => Promise.resolve([]),
+        updateMany: () => Promise.resolve({ count: 0 }),
+      },
+      station: {
+        findMany: () => Promise.resolve([]),
+        updateMany: () => Promise.resolve({ count: 0 }),
+      },
+      stop: {
+        findMany: ({
+          select,
+        }: {
+          select: { uuid?: true; address_zh_tw?: true; address_en?: true }
+        }) => {
+          if (select.address_zh_tw || select.address_en) {
+            return Promise.resolve([
+              {
+                uuid: 'TPE-stop-1',
+                address_zh_tw: null,
+                address_en: null,
+              },
+            ])
+          }
+
+          return Promise.resolve(existingStops)
+        },
+        updateMany: (args: (typeof stopUpdateManyArgs)[number]) => {
+          stopUpdateManyArgs.push(args)
+
+          return Promise.resolve({ count: args.where.uuid.in?.length ?? 0 })
+        },
+      },
+    } as unknown as PrismaService
+    const stopBulkWriterService = {
+      upsertStationGroups: () => Promise.resolve(),
+      upsertStations: () => Promise.resolve(),
+      upsertStops: () => Promise.resolve(),
+      upsertRouteStops: () => Promise.resolve(),
+      upsertRouteShapes: () => Promise.resolve(),
+    } as unknown as StopBulkWriterService
+    const service = new StopPersistenceService(
+      prismaService,
+      stopBulkWriterService,
+    )
+    const records: StopSyncRecords = {
+      stationGroups: [],
+      stations: [stationRecord],
+      stops: [stopRecord],
+      routeStops: [],
+      routeShapes: [],
+    }
+
+    await expect(
+      service.persistStops(records, { city: CityNameType.TAIPEI }),
+    ).resolves.toMatchObject({
+      records_deactivated: 501,
+    })
+    expect(stopUpdateManyArgs).toHaveLength(2)
+    expect(stopUpdateManyArgs[0].where.uuid.in).toHaveLength(500)
+    expect(stopUpdateManyArgs[0].where.uuid.notIn).toBeUndefined()
+    expect(stopUpdateManyArgs[1].where.uuid.in).toHaveLength(1)
+    expect(stopUpdateManyArgs[1].where.uuid.notIn).toBeUndefined()
+  })
 })

--- a/apps/api/src/sync/stop-persistence.service.ts
+++ b/apps/api/src/sync/stop-persistence.service.ts
@@ -20,6 +20,7 @@ export type StopSyncStage =
 
 interface PersistStopsOptions {
   city: CityNameType
+  syncStations?: boolean
   onStageStart?: (stage: StopSyncStage, totalCount: number) => void
   onProgress?: (
     stage: StopSyncStage,
@@ -37,7 +38,12 @@ export class StopPersistenceService {
 
   async persistStops(
     records: StopSyncRecords,
-    { city, onStageStart, onProgress }: PersistStopsOptions,
+    {
+      city,
+      syncStations = true,
+      onStageStart,
+      onProgress,
+    }: PersistStopsOptions,
   ): Promise<SyncResult> {
     if (records.stops.length === 0) {
       throw new Error(`TDX returned 0 stops for ${city}.`)
@@ -48,10 +54,12 @@ export class StopPersistenceService {
       onStageStart,
       onProgress,
     })
-    await this.persistStations(records.stations, prismaCity, {
-      onStageStart,
-      onProgress,
-    })
+    if (syncStations) {
+      await this.persistStations(records.stations, prismaCity, {
+        onStageStart,
+        onProgress,
+      })
+    }
     const stopResult = await this.persistStopRecords(records.stops, {
       onStageStart,
       onProgress,

--- a/apps/api/src/sync/stop-persistence.service.ts
+++ b/apps/api/src/sync/stop-persistence.service.ts
@@ -193,7 +193,6 @@ export class StopPersistenceService {
 
     const deactivatedStopCount = await this.deactivateMissingStops(
       city,
-      existingStops.map((stop) => stop.uuid),
       incomingStopUuids,
     )
 
@@ -386,10 +385,16 @@ export class StopPersistenceService {
 
   private async deactivateMissingStops(
     city: StopSyncRecords['stops'][number]['city'],
-    existingUuids: string[],
     incomingUuids: string[],
   ): Promise<number> {
-    const missingUuids = this.getMissingUuids(existingUuids, incomingUuids)
+    const activeStops = await this.prismaService.stop.findMany({
+      where: { city, is_active: true },
+      select: { uuid: true },
+    })
+    const missingUuids = this.getMissingUuids(
+      activeStops.map((stop) => stop.uuid),
+      incomingUuids,
+    )
     const inactiveAt = new Date()
     let deactivatedCount = 0
 

--- a/apps/api/src/sync/stop-persistence.service.ts
+++ b/apps/api/src/sync/stop-persistence.service.ts
@@ -9,6 +9,8 @@ import {
 import { createProgressCounter } from './sync-progress.js'
 import type { SyncResult } from './sync-result.js'
 
+const DEACTIVATE_UUID_BATCH_SIZE = 500
+
 export type StopSyncStage =
   | 'station_groups'
   | 'stations'
@@ -93,18 +95,7 @@ export class StopPersistenceService {
 
     if (stationGroups.length === 0) return
 
-    const inactiveAt = new Date()
-    await this.prismaService.stationGroup.updateMany({
-      where: {
-        city,
-        uuid: { notIn: incomingUuids },
-        is_active: true,
-      },
-      data: {
-        is_active: false,
-        inactive_at: inactiveAt,
-      },
-    })
+    await this.deactivateMissingStationGroups(city, incomingUuids)
   }
 
   private async persistStations(
@@ -140,18 +131,7 @@ export class StopPersistenceService {
       },
     )
 
-    const inactiveAt = new Date()
-    await this.prismaService.station.updateMany({
-      where: {
-        city,
-        uuid: { notIn: incomingUuids },
-        is_active: true,
-      },
-      data: {
-        is_active: false,
-        inactive_at: inactiveAt,
-      },
-    })
+    await this.deactivateMissingStations(city, incomingUuids)
   }
 
   private async persistStopRecords(
@@ -203,24 +183,17 @@ export class StopPersistenceService {
       },
     )
 
-    const inactiveAt = new Date()
-    const deactivatedStops = await this.prismaService.stop.updateMany({
-      where: {
-        city,
-        uuid: { notIn: incomingStopUuids },
-        is_active: true,
-      },
-      data: {
-        is_active: false,
-        inactive_at: inactiveAt,
-      },
-    })
+    const deactivatedStopCount = await this.deactivateMissingStops(
+      city,
+      existingStops.map((stop) => stop.uuid),
+      incomingStopUuids,
+    )
 
     return {
       records_read: stops.length,
       records_created: recordsCreated,
       records_updated: recordsUpdated,
-      records_deactivated: deactivatedStops.count,
+      records_deactivated: deactivatedStopCount,
     }
   }
 
@@ -343,6 +316,113 @@ export class StopPersistenceService {
     if (!options.onProgress || !progress.shouldReport(persistedCount)) return
 
     await options.onProgress(stage, persistedCount, totalCount)
+  }
+
+  private async deactivateMissingStationGroups(
+    city: StopSyncRecords['stationGroups'][number]['city'],
+    incomingUuids: string[],
+  ): Promise<void> {
+    const activeStationGroups = await this.prismaService.stationGroup.findMany({
+      where: { city, is_active: true },
+      select: { uuid: true },
+    })
+    const missingUuids = this.getMissingUuids(
+      activeStationGroups.map((group) => group.uuid),
+      incomingUuids,
+    )
+    const inactiveAt = new Date()
+
+    for (const uuidBatch of this.chunk(missingUuids)) {
+      await this.prismaService.stationGroup.updateMany({
+        where: {
+          city,
+          uuid: { in: uuidBatch },
+          is_active: true,
+        },
+        data: {
+          is_active: false,
+          inactive_at: inactiveAt,
+        },
+      })
+    }
+  }
+
+  private async deactivateMissingStations(
+    city: StopSyncRecords['stations'][number]['city'],
+    incomingUuids: string[],
+  ): Promise<void> {
+    const activeStations = await this.prismaService.station.findMany({
+      where: { city, is_active: true },
+      select: { uuid: true },
+    })
+    const missingUuids = this.getMissingUuids(
+      activeStations.map((station) => station.uuid),
+      incomingUuids,
+    )
+    const inactiveAt = new Date()
+
+    for (const uuidBatch of this.chunk(missingUuids)) {
+      await this.prismaService.station.updateMany({
+        where: {
+          city,
+          uuid: { in: uuidBatch },
+          is_active: true,
+        },
+        data: {
+          is_active: false,
+          inactive_at: inactiveAt,
+        },
+      })
+    }
+  }
+
+  private async deactivateMissingStops(
+    city: StopSyncRecords['stops'][number]['city'],
+    existingUuids: string[],
+    incomingUuids: string[],
+  ): Promise<number> {
+    const missingUuids = this.getMissingUuids(existingUuids, incomingUuids)
+    const inactiveAt = new Date()
+    let deactivatedCount = 0
+
+    for (const uuidBatch of this.chunk(missingUuids)) {
+      const deactivatedStops = await this.prismaService.stop.updateMany({
+        where: {
+          city,
+          uuid: { in: uuidBatch },
+          is_active: true,
+        },
+        data: {
+          is_active: false,
+          inactive_at: inactiveAt,
+        },
+      })
+
+      deactivatedCount += deactivatedStops.count
+    }
+
+    return deactivatedCount
+  }
+
+  private getMissingUuids(
+    existingUuids: string[],
+    incomingUuids: string[],
+  ): string[] {
+    const incomingUuidSet = new Set(incomingUuids)
+
+    return existingUuids.filter((uuid) => !incomingUuidSet.has(uuid))
+  }
+
+  private chunk<T>(records: T[]): T[][] {
+    const chunks: T[][] = []
+    let index = 0
+
+    while (index < records.length) {
+      chunks.push(records.slice(index, index + DEACTIVATE_UUID_BATCH_SIZE))
+      index += DEACTIVATE_UUID_BATCH_SIZE
+    }
+
+    return chunks
   }
 
   private async loadStationGroupIds(

--- a/apps/api/src/sync/stops-sync.service.spec.ts
+++ b/apps/api/src/sync/stops-sync.service.spec.ts
@@ -199,4 +199,66 @@ describe('StopsSyncService', () => {
     expect(fetchStationGroupsCallCount).toBe(0)
     expect(persistedStationGroupCounts).toEqual([0])
   })
+
+  it('skips stations when TDX does not support Station/City for the city', async () => {
+    let fetchStationsCallCount = 0
+    const tdxClientService = {
+      fetchStationGroups: () => Promise.resolve([]),
+      fetchStations: () => {
+        fetchStationsCallCount += 1
+
+        return Promise.resolve([])
+      },
+      fetchStops: () =>
+        Promise.resolve([
+          {
+            StopUID: 'MFK-stop-1',
+            StopID: 'stop-1',
+            StopName: { Zh_tw: '測試站', En: 'Test Stop' },
+            StopPosition: { PositionLat: 26, PositionLon: 120 },
+            AuthorityID: '004',
+            StationID: 'station-1',
+            UpdateTime: '2026-06-25T00:00:00+08:00',
+            VersionID: 1,
+          },
+        ]),
+      fetchStopOfRoutes: () => Promise.resolve([]),
+    }
+    const persistedSyncStations: Array<boolean | undefined> = []
+    const stopPersistenceService = {
+      persistStops: (
+        _records: unknown,
+        options: { syncStations?: boolean },
+      ) => {
+        persistedSyncStations.push(options.syncStations)
+
+        return Promise.resolve({
+          records_read: 1,
+          records_created: 1,
+          records_updated: 0,
+          records_deactivated: 0,
+        })
+      },
+    }
+    const syncCheckpointService = {
+      touch: () => Promise.resolve(),
+    }
+    const service = await createService({
+      tdxClientService,
+      stopPersistenceService,
+      syncCheckpointService,
+    })
+
+    await expect(
+      service.syncCityStops(CityNameType.LIENCHIANG_COUNTY, 'sync-run-id'),
+    ).resolves.toEqual({
+      records_read: 1,
+      records_created: 1,
+      records_updated: 0,
+      records_deactivated: 0,
+    })
+
+    expect(fetchStationsCallCount).toBe(0)
+    expect(persistedSyncStations).toEqual([false])
+  })
 })

--- a/apps/api/src/sync/stops-sync.service.ts
+++ b/apps/api/src/sync/stops-sync.service.ts
@@ -27,6 +27,9 @@ const STATION_GROUP_SUPPORTED_CITIES = new Set<CityNameType>([
   CityNameType.PENGHU_COUNTY,
   CityNameType.KEELUNG,
 ])
+const STATION_UNSUPPORTED_CITIES = new Set<CityNameType>([
+  CityNameType.LIENCHIANG_COUNTY,
+])
 
 @Injectable()
 export class StopsSyncService {
@@ -136,10 +139,7 @@ export class StopsSyncService {
 
     try {
       const stationGroups = await this.fetchStationGroups(city, syncRunId)
-      const stations = await this.tdxClientService.fetchStations(
-        city,
-        syncRunId,
-      )
+      const stations = await this.fetchStations(city, syncRunId)
       const stops = await this.tdxClientService.fetchStops(city, syncRunId)
       const stopOfRoutes = await this.tdxClientService.fetchStopOfRoutes(
         city,
@@ -160,6 +160,7 @@ export class StopsSyncService {
 
       return await this.stopPersistenceService.persistStops(records, {
         city,
+        syncStations: this.isStationSupported(city),
         onStageStart: (stage, totalCount) => {
           this.logger.log(
             `Stop sync ${syncRunId}: persisting ${totalCount} ${this.stageLabel(stage)} for ${city}.`,
@@ -187,6 +188,22 @@ export class StopsSyncService {
     )
 
     return []
+  }
+
+  private async fetchStations(city: CityNameType, syncRunId: string) {
+    if (this.isStationSupported(city)) {
+      return this.tdxClientService.fetchStations(city, syncRunId)
+    }
+
+    this.logger.log(
+      `Stop sync ${syncRunId}: skipping stations for ${city} because TDX does not support Station/City for this city.`,
+    )
+
+    return []
+  }
+
+  private isStationSupported(city: CityNameType): boolean {
+    return !STATION_UNSUPPORTED_CITIES.has(city)
   }
 
   private stageLabel(stage: StopSyncStage): string {


### PR DESCRIPTION
## Related

Part of #31
Related to #46 

## Summary

Stabilize the API stop sync flow so it can complete a full Taiwan stop import against TDX data.

This PR fixes the main issues found while running the stop sync end to end: large deactivation queries exceeding database parameter limits, duplicate TDX stop-of-route records causing raw SQL upserts to fail, and TDX endpoints that do not support every city for every resource.

## What Changed

- Batched stop sync deactivation logic to avoid huge `notIn` query parameter lists.
- Deduplicated bulk upsert records before raw SQL writes.
  - station groups by `uuid`
  - stations by `uuid`
  - stops by `uuid`
  - route stops by `subroute_id + sequence`
  - route shapes by `subroute_id`
- Skipped unsupported optional TDX resources by city.
  - `StationGroup/City` is skipped for unsupported cities.
  - `Station/City` is skipped for `LienchiangCounty`.
- Kept required stop data strict, so empty stop responses still fail fast.
- Added unit coverage for:
  - stop deactivation batching
  - bulk writer deduplication
  - unsupported station city handling
  - station persistence skip mode
- Added sync troubleshooting documentation for:
  - database query parameter limit failures
  - `ON CONFLICT DO UPDATE command cannot affect row a second time`
  - TDX duplicate StopOfRoute records by operator
  - TDX endpoint city support differences

## Validation

Ran locally:

- `pnpm --filter @bus/api lint`
- `pnpm --filter @bus/api typecheck`
- `pnpm --filter @bus/api test:unit -- stops-sync.service.spec.ts stop-persistence.service.spec.ts --runInBand`

Also completed a full stop sync run:

```text
Stop sync 860dba21-bd3d-4f66-808a-7ba6b8ebde99 succeeded:
read 134761, created 101161, updated 33600, deactivated 108.
```

## Scope Notes

This PR focuses on making stop sync finish reliably.

Left for follow-up PRs:

- database/table size inspection
- read APIs for synced route/stop data
- frontend integration with DB-backed API data
- richer sync monitoring UI or manager app
- optional debug diagnostics for duplicate TDX records